### PR TITLE
Restart from sync in case of error

### DIFF
--- a/include/PacketFormat.h
+++ b/include/PacketFormat.h
@@ -1,0 +1,102 @@
+/******************************************************************************
+       Module: PICP.h
+     Engineer: Vimalraj Rajasekharan
+  Description: Header of class to define and manage Probe server
+               packet formatting
+  Date           Initials    Description
+  01-Dec-2023    VR          Initial
+******************************************************************************/
+#pragma once
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif // WIN32
+
+typedef enum PICPType
+{
+    PICP_TYPE_RESPONSE = 0x00,
+    PICP_TYPE_PROBE = 0x01,
+    PICP_TYPE_INTERNAL = 0x02,
+    PICP_TYPE_PROGRESS = 0x03,
+
+    PICP_TYPE_INVALID
+} ePICPType;
+
+typedef enum PICPCommand
+{
+    PICP_CMD_OPEN_DEVICE,
+    PICP_CMD_CLOSE_DEVICE,
+
+    PICP_CMD_BULK_READ,
+    PICP_CMD_REGISTER_READ,
+    PICP_CMD_BULK_WRITE,
+    PICP_CMD_REGISTER_WRITE,
+
+    PICP_CMD_PROCESS_COMMAND,
+    PICP_CMD_TRACE_READ,
+
+    PICP_CMD_DEVICE_LIST,
+    PICP_CMD_FLASH_FPGA,
+    PICP_CMD_LOAD_FPGA,
+    PICP_CMD_ERASE_FPGA,
+
+    PICP_CMD_TERMINATE,
+
+    PICP_CMD_TRACE_START_STREAMING,
+    PICP_CMD_TRACE_STOP_STREAMING,
+
+    PICP_CMD_INVALID
+} ePICPCommand;
+
+struct PICPHeader
+{
+    uint8_t id;
+    uint8_t type;
+    uint32_t command;
+    uint32_t datalength;
+};
+
+struct PICPFooter
+{
+    uint32_t crc;
+};
+
+// Probe Interface Communication Protocol (PICP)
+class PICP
+{
+private:
+    bool m_bIsValid;
+    bool m_bIsCreated;
+    uint8_t *m_pucBuffer;
+    uint32_t m_ulCurIndex;
+
+    PICPType m_eType;
+    uint32_t m_eCommand;
+    uint32_t m_ulMaxDataSize;
+    uint32_t m_ulCRC;
+
+    PICP();
+
+public:
+    PICP(uint32_t ulMaxDataSize, PICPType eType, uint32_t eCmd = PICP_CMD_INVALID);
+    PICP(uint8_t *pBuffer, uint32_t ulSize);
+    ~PICP();
+
+    bool Validate();
+    bool AttachData(const uint8_t *pBuffer, uint32_t ulSize);
+    bool GetNextData(uint8_t* pBuffer, uint32_t ulSize);
+    uint8_t *GetNextDataAddress(uint32_t *ulSize);
+    uint8_t *GetPacketToSend(uint32_t *ulSize = NULL);
+
+    bool SetType(PICPType eType);
+    bool SetResponse(uint32_t ulResponse);
+    bool SetDataSize(uint32_t ulSize);
+
+    PICPType GetType() { return m_eType; };
+    PICPCommand GetCommand() { return static_cast<PICPCommand>(m_eCommand); };
+    uint32_t GetResponse() { return m_eCommand; };
+    uint32_t GetDataSize() { return m_ulMaxDataSize; };
+    uint32_t GetCurrentPacketSize() { return (m_ulCurIndex + sizeof(PICPFooter)); };
+    static uint32_t GetMinimumSize() { return (sizeof(PICPHeader) + sizeof(PICPFooter)); };
+};

--- a/include/ProbeIntf.h
+++ b/include/ProbeIntf.h
@@ -1,0 +1,30 @@
+/******************************************************************************
+       Module: ProbeIntf.h
+     Engineer: Vimalraj Rajasekharan
+  Description: Header of interface class for Probe Server interface
+  Date           Initials    Description
+  01-Dec-2023    VR          Initial
+******************************************************************************/
+#pragma once
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif // WIN32
+
+#define ERROR_PROBE_INTF_SUCCESS                    0x30
+#define ERROR_PROBE_INTF_SERVER_UNREACHABLE         0x31
+
+class ProbeIntf
+{
+public:
+    virtual ~ProbeIntf() {}
+
+public:
+    virtual int32_t open() = 0;
+    virtual int32_t close() = 0;
+
+    virtual int32_t write(uint8_t *data, uint32_t size) = 0;
+    virtual int32_t read(uint8_t *data, uint32_t* size) = 0;
+    virtual uint32_t readtrace(uint8_t *data, uint32_t *size) = 0;
+};

--- a/include/SocketIntf.h
+++ b/include/SocketIntf.h
@@ -1,0 +1,39 @@
+/******************************************************************************
+       Module: SocketIntf.h
+     Engineer: Vimalraj Rajasekharan
+  Description: Header of class for Probe server interface to be used by clients
+  Date           Initials    Description
+  01-Dec-2023    VR          Initial
+******************************************************************************/
+#pragma once
+#include <stdint.h>
+#include "ProbeIntf.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winsock.h>
+#endif // WIN32
+
+#define BUFF_SIZE 2*1024
+
+#ifdef __LINUX
+typedef int32_t SOCKET;
+#define INVALID_SOCKET  (SOCKET)(~0)
+#endif
+
+class SocketIntf : public ProbeIntf
+{
+    SOCKET m_socket;
+    uint16_t m_usPort;
+
+public:
+    SocketIntf(uint16_t usPort);
+    ~SocketIntf();
+
+    virtual int32_t open();
+    virtual int32_t close();
+
+    virtual int32_t write(uint8_t *data, uint32_t size);
+    virtual int32_t read(uint8_t *data, uint32_t *size);
+    virtual uint32_t readtrace(uint8_t *data, uint32_t *size);
+};

--- a/include/dqr_profiler.h
+++ b/include/dqr_profiler.h
@@ -1,0 +1,905 @@
+/* Copyright 2022 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef DQR_PROFILER_HPP_
+#define DQR_PROFILER_HPP_
+
+// PUBLIC definitions
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cstring>
+#include <cstdint>
+#include <cassert>
+
+//#define DO_TIMES	1
+
+#define DQR_PROFILER_MAXCORES	16
+
+#define PROFILER_DEFAULTOBJDUMPNAME	"riscv64-unknown-elf-objdump"
+
+extern int profiler_globalDebugFlag;
+extern const char* const DQR_PROFILER_VERSION;
+
+class PROFILER_CTF {
+public:
+	struct trace_packet_header {
+		uint32_t magic;
+		uint8_t uuid[16];				// optional?
+		uint32_t stream_id;
+		uint64_t stream_instance_id;	// optional?
+	};
+
+	enum event_type {
+		event_tracePoint = 0,
+		event_funcEntry = 1,
+		event_funcExit = 2,
+		event_stateDumpStart = 3,
+		event_stateDumpBinInfo = 4,
+		event_stateDumpEnd = 7,
+		event_extended = 0xffff
+	};
+
+	// metadata file needs to have an env struct!!
+
+	typedef uint64_t uint64_clock_monotonic_t;
+
+	struct stream_packet_context {
+		uint64_clock_monotonic_t timestamp_begin;
+		uint64_clock_monotonic_t timestamp_end;
+		uint64_t content_size;
+		uint64_t packet_size;
+		uint64_t packet_seq_num;
+		uint64_t events_discarded;	// or unsigned long?
+		uint32_t cpu_id;
+	};
+
+	struct stream_packet_header_extended {
+		uint16_t id;	// this should be 0xffff for extended headers
+		uint32_t extended_id;
+		uint64_clock_monotonic_t extended_timestamp;
+	};
+
+	struct stream_event_context {
+		uint32_t _vpid;
+		uint32_t _vtid;
+		uint8_t  _procname[17];
+	};
+
+	struct stream_event_callret {
+		uint64_t src;
+		uint64_t dst;
+	};
+
+	enum event_t {
+		et_controlIndex,
+		et_extTriggerIndex,
+		et_callRetIndex,
+		et_exceptionIndex,
+		et_interruptIndex,
+		et_mContextIndex,
+		et_sContextIndex,
+		et_watchpointIndex,
+		et_periodicIndex,
+		et_numEventTypes
+	};
+};
+
+class TraceDqrProfiler 
+{
+public:
+	typedef uint32_t RV_INST;
+
+	typedef uint64_t ADDRESS;
+	typedef uint64_t TIMESTAMP;
+	typedef int RCode;
+
+	enum {
+		TRACE_HAVE_INSTINFO = 0x01,
+		TRACE_HAVE_SRCINFO = 0x02,
+		TRACE_HAVE_MSGINFO = 0x04,
+		TRACE_HAVE_ITCPRINTINFO = 0x08,
+	};
+
+	typedef enum {
+		MSEO_NORMAL = 0x00,
+		MSEO_VAR_END = 0x01,
+		MSEO_END = 0x03,
+	} MSEO;
+
+	typedef enum {
+		DQERR_OK = 0,		// no error
+		DQERR_OPEN = 1,		// can't open file
+		DQERR_EOF = 2,		// at file eof
+		DQERR_EOM = 3,		// at file eom
+		DQERR_BM = 4,		// bad message (mallformed)
+		DQERR_ERR = 5,		// general error
+		DQERR_DONE = 6,		// done with trace message
+	} DQErr;
+
+	typedef enum {
+		TCODE_DEBUG_STATUS = 0,
+		TCODE_DEVICE_ID = 1,
+		TCODE_OWNERSHIP_TRACE = 2,
+		TCODE_DIRECT_BRANCH = 3,
+		TCODE_INDIRECT_BRANCH = 4,
+		TCODE_DATA_WRITE = 5,
+		TCODE_DATA_READ = 6,
+		TCODE_DATA_ACQUISITION = 7,
+		TCODE_ERROR = 8,
+		TCODE_SYNC = 9,
+		TCODE_CORRECTION = 10,
+		TCODE_DIRECT_BRANCH_WS = 11,
+		TCODE_INDIRECT_BRANCH_WS = 12,
+		TCODE_DATA_WRITE_WS = 13,
+		TCODE_DATA_READ_WS = 14,
+		TCODE_WATCHPOINT = 15,
+		TCODE_OUTPUT_PORTREPLACEMENT = 20,
+		TCODE_INPUT_PORTREPLACEMENT = 21,
+		TCODE_AUXACCESS_READ = 22,
+		TCODE_AUXACCESS_WRITE = 23,
+		TCODE_AUXACCESS_READNEXT = 24,
+		TCODE_AUXACCESS_WRITENEXT = 25,
+		TCODE_AUXACCESS_RESPONSE = 26,
+		TCODE_RESOURCEFULL = 27,
+		TCODE_INDIRECTBRANCHHISTORY = 28,
+		TCODE_INDIRECTBRANCHHISTORY_WS = 29,
+		TCODE_REPEATBRANCH = 30,
+		TCODE_REPEATINSTRUCTION = 31,
+		TCODE_REPEATINSTRUCTION_WS = 32,
+		TCODE_CORRELATION = 33,
+		TCODE_INCIRCUITTRACE = 34,
+		TCODE_INCIRCUITTRACE_WS = 35,
+
+		TCODE_UNDEFINED
+	} TCode;
+
+	typedef enum {
+		EVCODE_ENTERDEBUG = 0,
+		EVCODE_TRACEDISABLE = 4,
+		EVCODE_ENTERRESET = 8
+	} EVCode;
+
+	typedef enum {
+		SYNC_EVTI = 0,
+		SYNC_EXIT_RESET = 1,
+		SYNC_T_CNT = 2,
+		SYNC_EXIT_DEBUG = 3,
+		SYNC_I_CNT_OVERFLOW = 4,
+		SYNC_TRACE_ENABLE = 5,
+		SYNC_WATCHPINT = 6,
+		SYNC_FIFO_OVERRUN = 7,
+		SYNC_EXIT_POWERDOWN = 9,
+		SYNC_MESSAGE_CONTENTION = 11,
+		SYNC_PC_SAMPLE = 15,
+		SYNC_NONE
+	} SyncReason;
+
+	typedef enum {
+		ICT_CONTROL = 0,
+		ICT_EXT_TRIG = 8,
+		ICT_INFERABLECALL = 9,
+		ICT_EXCEPTION = 10,
+		ICT_INTERRUPT = 11,
+		ICT_CONTEXT = 13,
+		ICT_WATCHPOINT = 14,
+		ICT_PC_SAMPLE = 15,
+		ICT_NONE
+	} ICTReason;
+
+	typedef enum {
+		ICT_CONTROL_NONE = 0,
+		ICT_CONTROL_TRACE_ON = 2,
+		ICT_CONTROL_TRACE_OFF = 3,
+		ICT_CONTROL_EXIT_DEBUG = 4,
+		ICT_CONTROL_ENTER_DEBUG = 5,
+		ICT_CONTROL_EXIT_RESET = 6,
+		ICT_CONTROL_ENTER_RESET = 8,
+	} ICTControl;
+
+	typedef enum {
+		ITC_OPT_NONE = 0,
+		ITC_OPT_PRINT = 1,
+		ITC_OPT_NLS = 2,
+	} ITCOptions;
+
+	typedef enum {
+		BTYPE_INDIRECT = 0,
+		BTYPE_EXCEPTION = 1,
+		BTYPE_HARDWARE = 2,
+
+		BTYPE_UNDEFINED
+	} BType;
+
+	typedef enum {
+		ADDRDISP_WIDTHAUTO = 1,
+		ADDRDISP_SEP = 2,
+	} AddrDisp;
+
+	enum InstType {
+		INST_UNKNOWN = 0,
+		INST_JAL,
+		INST_JALR,
+		INST_BEQ,
+		INST_BNE,
+		INST_BLT,
+		INST_BGE,
+		INST_BLTU,
+		INST_BGEU,
+		INST_C_J,
+		INST_C_JAL,
+		INST_C_JR,
+		INST_C_JALR,
+		INST_C_BEQZ,
+		INST_C_BNEZ,
+		INST_EBREAK,
+		INST_C_EBREAK,
+		INST_ECALL,
+		INST_MRET,
+		INST_SRET,
+		INST_URET,
+		// the following intTypes are generic and do not specify an actual instruction
+		INST_SCALER,
+		INST_VECT_ARITH,
+		INST_VECT_LOAD,
+		INST_VECT_STORE,
+		INST_VECT_AMO,
+		INST_VECT_AMO_WW,
+		INST_VECT_CONFIG,
+	};
+
+	enum CountType {
+		COUNTTYPE_none,
+		COUNTTYPE_i_cnt,
+		COUNTTYPE_history,
+		COUNTTYPE_taken,
+		COUNTTYPE_notTaken
+	};
+
+	enum Reg {
+		REG_0 = 0,
+		REG_1 = 1,
+		REG_2 = 2,
+		REG_3 = 3,
+		REG_4 = 4,
+		REG_5 = 5,
+		REG_6 = 6,
+		REG_7 = 7,
+		REG_8 = 8,
+		REG_9 = 9,
+		REG_10 = 10,
+		REG_11 = 11,
+		REG_12 = 12,
+		REG_13 = 13,
+		REG_14 = 14,
+		REG_15 = 15,
+		REG_16 = 16,
+		REG_17 = 17,
+		REG_18 = 18,
+		REG_19 = 19,
+		REG_20 = 20,
+		REG_21 = 21,
+		REG_22 = 22,
+		REG_23 = 23,
+		REG_24 = 24,
+		REG_25 = 25,
+		REG_26 = 26,
+		REG_27 = 27,
+		REG_28 = 28,
+		REG_29 = 29,
+		REG_30 = 30,
+		REG_31 = 31,
+		REG_unknown,
+	};
+
+	enum TraceType {
+		TRACETYPE_unknown = 0,
+		TRACETYPE_BTM,
+		TRACETYPE_HTM,
+		TRACETYPE_VCD,
+	};
+
+	enum CallReturnFlag {
+		isNone = 0,
+		isCall = (1 << 0),
+		isReturn = (1 << 1),
+		isSwap = (1 << 2),
+		isInterrupt = (1 << 3),
+		isException = (1 << 4),
+		isExceptionReturn = (1 << 5),
+	};
+
+	enum BranchFlags {
+		BRFLAG_none = 0,
+		BRFLAG_unknown,
+		BRFLAG_taken,
+		BRFLAG_notTaken,
+	};
+
+	enum tsType {
+		TS_full,
+		TS_rel,
+	};
+
+	enum pathType {
+		PATH_RAW,
+		PATH_TO_WINDOWS,
+		PATH_TO_UNIX,
+	};
+
+	enum CATraceType {
+		CATRACE_NONE,
+		CATRACE_INSTRUCTION,
+		CATRACE_VECTOR,
+	};
+
+	enum CAVectorTraceFlags {
+		CAVFLAG_V0 = 0x20,
+		CAVFLAG_V1 = 0x10,
+		CAVFLAG_VISTART = 0x08,
+		CAVFLAG_VIARITH = 0x04,
+		CAVFLAG_VISTORE = 0x02,
+		CAVFLAG_VILOAD = 0x01,
+	};
+
+	enum CATraceFlags {
+		CAFLAG_NONE = 0x00,
+		CAFLAG_PIPE0 = 0x01,
+		CAFLAG_PIPE1 = 0x02,
+		CAFLAG_SCALER = 0x04,
+		CAFLAG_VSTART = 0x08,
+		CAFLAG_VSTORE = 0x10,
+		CAFLAG_VLOAD = 0x20,
+		CAFLAG_VARITH = 0x40,
+	};
+
+	struct nlStrings {
+		int nf;
+		int signedMask;
+		char* format;
+	};
+};
+
+// class ProfilerInstruction: work with an instruction
+class ProfilerInstruction {
+public:
+	void addressToText(char* dst, size_t len, int labelLevel);
+	std::string addressToString(int labelLevel);
+	std::string addressLabelToString();
+	//	void opcodeToText();
+	void instructionToText(char* dst, size_t len, int labelLevel);
+	std::string instructionToString(int labelLevel);
+
+	static int        addrSize;
+	static uint32_t   addrDispFlags;
+	static int        addrPrintWidth;
+
+	uint8_t           coreId;
+
+	int               CRFlag;
+	int               brFlags; // this is an int instead of TraceDqrProfiler::BancheFlags because it is easier to work with in java
+
+	TraceDqrProfiler::ADDRESS address;
+	int               instSize;
+	TraceDqrProfiler::RV_INST instruction;
+	char* instructionText;
+
+#ifdef SWIG
+	% immutable		addressLabel;
+#endif // SWIG
+	const char* addressLabel;
+	int               addressLabelOffset;
+
+	TraceDqrProfiler::TIMESTAMP timestamp;
+
+	uint32_t            caFlags;
+	uint32_t            pipeCycles;
+	uint32_t            VIStartCycles;
+	uint32_t            VIFinishCycles;
+
+	uint8_t             qDepth;
+	uint8_t             arithInProcess;
+	uint8_t             loadInProcess;
+	uint8_t             storeInProcess;
+
+	uint32_t r0Val;
+	uint32_t r1Val;
+	uint32_t wVal;
+};
+
+// class ProfilerSource: Helper class for source code information for an address
+
+class ProfilerSource {
+public:
+	std::string  sourceFileToString();
+	std::string  sourceFileToString(std::string path);
+	std::string  sourceLineToString();
+	std::string  sourceFunctionToString();
+	uint8_t      coreId;
+#ifdef SWIG
+	% immutable sourceFile;
+	% immutable sourceFunction;
+	% immutable sourceLine;
+#endif // SWIG
+	const char* sourceFile;
+	int          cutPathIndex;
+	const char* sourceFunction;
+	const char* sourceLine;
+	unsigned int sourceLineNum;
+
+private:
+	const char* stripPath(const char* path);
+};
+
+
+class ProfilerNexusMessage {
+public:
+	ProfilerNexusMessage();
+	bool processITCPrintData(class ITCPrint* itcPrint);
+	void messageToText(char* dst, size_t dst_len, int level);
+	std::string messageToString(int detailLevel);
+	double seconds();
+
+	void dumpRawMessage();
+	void dump();
+
+	static uint32_t targetFrequency;
+
+	int                 msgNum;
+	TraceDqrProfiler::TCode     tcode;
+	bool       	        haveTimestamp;
+	TraceDqrProfiler::TIMESTAMP timestamp;
+	TraceDqrProfiler::ADDRESS   currentAddress;
+	TraceDqrProfiler::TIMESTAMP time;
+
+	uint8_t             coreId;
+
+	union {
+		struct {
+			int	i_cnt;
+		} directBranch;
+		struct {
+			int          i_cnt;
+			TraceDqrProfiler::ADDRESS u_addr;
+			TraceDqrProfiler::BType   b_type;
+		} indirectBranch;
+		struct {
+			int             i_cnt;
+			TraceDqrProfiler::ADDRESS    f_addr;
+			TraceDqrProfiler::SyncReason sync;
+		} directBranchWS;
+		struct {
+			int             i_cnt;
+			TraceDqrProfiler::ADDRESS    f_addr;
+			TraceDqrProfiler::BType      b_type;
+			TraceDqrProfiler::SyncReason sync;
+		} indirectBranchWS;
+		struct {
+			int             i_cnt;
+			TraceDqrProfiler::ADDRESS    u_addr;
+			TraceDqrProfiler::BType      b_type;
+			uint64_t		history;
+		} indirectHistory;
+		struct {
+			int             i_cnt;
+			TraceDqrProfiler::ADDRESS    f_addr;
+			TraceDqrProfiler::BType      b_type;
+			uint64_t		history;
+			TraceDqrProfiler::SyncReason sync;
+		} indirectHistoryWS;
+		struct {
+			TraceDqrProfiler::RCode rCode;
+			union {
+				int i_cnt;
+				uint64_t history;
+				uint32_t takenCount;
+				uint32_t notTakenCount;
+			};
+		} resourceFull;
+		struct {
+			int             i_cnt;
+			TraceDqrProfiler::ADDRESS    f_addr;
+			TraceDqrProfiler::SyncReason sync;
+		} sync;
+		struct {
+			uint8_t etype;
+		} error;
+		struct {
+			uint64_t history;
+			int     i_cnt;
+			uint8_t cdf;
+			uint8_t evcode;
+		} correlation;
+		struct {
+			uint32_t data;
+			uint32_t addr;
+		} auxAccessWrite;
+		struct {
+			uint32_t idTag;
+			uint32_t data;
+		} dataAcquisition;
+		struct {
+			uint32_t process;
+		} ownership;
+		struct {
+			TraceDqrProfiler::ICTReason cksrc;
+			uint8_t ckdf;
+			TraceDqrProfiler::ADDRESS ckdata[2];
+		} ict;
+		struct {
+			TraceDqrProfiler::ICTReason cksrc;
+			uint8_t ckdf;
+			TraceDqrProfiler::ADDRESS ckdata[2];
+		} ictWS;
+	};
+
+	uint32_t offset;
+	uint8_t  rawData[32];
+
+	int getI_Cnt();
+	TraceDqrProfiler::ADDRESS    getU_Addr();
+	TraceDqrProfiler::ADDRESS    getF_Addr();
+	TraceDqrProfiler::ADDRESS    getNextAddr() { return currentAddress; };
+	TraceDqrProfiler::ADDRESS    getICTCallReturnTarget();
+	TraceDqrProfiler::BType      getB_Type();
+	TraceDqrProfiler::SyncReason getSyncReason();
+	uint8_t  getEType();
+	uint8_t  getCKDF();
+	TraceDqrProfiler::ICTReason  getCKSRC();
+	TraceDqrProfiler::ADDRESS getCKData(int i);
+	uint8_t  getCDF();
+	uint8_t  getEVCode();
+	uint32_t getData();
+	uint32_t getAddr();
+	uint32_t getIdTag();
+	uint32_t getProcess();
+	uint32_t getRCode();
+	uint64_t getRData();
+	uint64_t getHistory();
+};
+
+class ProfilerAnalytics {
+public:
+	ProfilerAnalytics();
+	~ProfilerAnalytics();
+
+	TraceDqrProfiler::DQErr updateTraceInfo(ProfilerNexusMessage& nm, uint32_t bits, uint32_t meso_bits, uint32_t ts_bits, uint32_t addr_bits);
+	TraceDqrProfiler::DQErr updateInstructionInfo(uint32_t core_id, uint32_t inst, int instSize, int crFlags, TraceDqrProfiler::BranchFlags brFlags);
+	int currentTraceMsgNum() { return num_trace_msgs_all_cores; }
+	void setSrcBits(int sbits) { srcBits = sbits; }
+	void toText(char* dst, int dst_len, int detailLevel);
+	std::string toString(int detailLevel);
+
+private:
+	TraceDqrProfiler::DQErr status;
+#ifdef DO_TIMES
+	class Timer* etimer;
+#endif // DO_TIMES
+
+	uint32_t cores;
+
+	int srcBits;
+
+	uint32_t num_trace_msgs_all_cores;
+	uint32_t num_trace_mseo_bits_all_cores;
+	uint32_t num_trace_bits_all_cores;
+	uint32_t num_trace_bits_all_cores_max;
+	uint32_t num_trace_bits_all_cores_min;
+
+	uint32_t num_inst_all_cores;
+	uint32_t num_inst16_all_cores;
+	uint32_t num_inst32_all_cores;
+
+	uint32_t num_branches_all_cores;
+
+	struct {
+		uint32_t num_inst;
+		uint32_t num_inst16;
+		uint32_t num_inst32;
+
+		uint32_t num_trace_msgs;
+		uint32_t num_trace_syncs;
+		uint32_t num_trace_dbranch;
+		uint32_t num_trace_ibranch;
+		uint32_t num_trace_dataacq;
+		uint32_t num_trace_dbranchws;
+		uint32_t num_trace_ibranchws;
+		uint32_t num_trace_ihistory;
+		uint32_t num_trace_ihistoryws;
+		uint32_t num_trace_takenhistory;
+		uint32_t num_trace_resourcefull;
+		uint32_t num_trace_correlation;
+		uint32_t num_trace_auxaccesswrite;
+		uint32_t num_trace_ownership;
+		uint32_t num_trace_error;
+		uint32_t num_trace_incircuittraceWS;
+		uint32_t num_trace_incircuittrace;
+
+		uint32_t trace_bits;
+		uint32_t trace_bits_max;
+		uint32_t trace_bits_min;
+		uint32_t trace_bits_mseo;
+
+		uint32_t max_hist_bits;
+		uint32_t min_hist_bits;
+		uint32_t max_notTakenCount;
+		uint32_t min_notTakenCount;
+		uint32_t max_takenCount;
+		uint32_t min_takenCount;
+
+		uint32_t trace_bits_sync;
+		uint32_t trace_bits_dbranch;
+		uint32_t trace_bits_ibranch;
+		uint32_t trace_bits_dataacq;
+		uint32_t trace_bits_dbranchws;
+		uint32_t trace_bits_ibranchws;
+		uint32_t trace_bits_ihistory;
+		uint32_t trace_bits_ihistoryws;
+		uint32_t trace_bits_resourcefull;
+		uint32_t trace_bits_correlation;
+		uint32_t trace_bits_auxaccesswrite;
+		uint32_t trace_bits_ownership;
+		uint32_t trace_bits_error;
+		uint32_t trace_bits_incircuittraceWS;
+		uint32_t trace_bits_incircuittrace;
+
+		uint32_t num_trace_ts;
+		uint32_t num_trace_uaddr;
+		uint32_t num_trace_faddr;
+		uint32_t num_trace_ihistory_taken_branches;
+		uint32_t num_trace_ihistory_nottaken_branches;
+		uint32_t num_trace_resourcefull_i_cnt;
+		uint32_t num_trace_resourcefull_hist;
+		uint32_t num_trace_resourcefull_takenCount;
+		uint32_t num_trace_resourcefull_notTakenCount;
+		uint32_t num_trace_resourcefull_taken_branches;
+		uint32_t num_trace_resourcefull_nottaken_branches;
+
+		uint32_t num_taken_branches;
+		uint32_t num_notTaken_branches;
+		uint32_t num_calls;
+		uint32_t num_returns;
+		uint32_t num_swaps;
+		uint32_t num_exceptions;
+		uint32_t num_exception_returns;
+		uint32_t num_interrupts;
+
+		uint32_t trace_bits_ts;
+		uint32_t trace_bits_ts_max;
+		uint32_t trace_bits_ts_min;
+
+		uint32_t trace_bits_uaddr;
+		uint32_t trace_bits_uaddr_max;
+		uint32_t trace_bits_uaddr_min;
+
+		uint32_t trace_bits_faddr;
+		uint32_t trace_bits_faddr_max;
+		uint32_t trace_bits_faddr_min;
+
+		uint32_t trace_bits_hist;
+	} core[DQR_PROFILER_MAXCORES];
+};
+
+class ProfilerCATraceRec {
+public:
+	ProfilerCATraceRec();
+	void dump();
+	void dumpWithCycle();
+	int consumeCAInstruction(uint32_t& pipe, uint32_t& cycles);
+	int consumeCAVector(uint32_t& record, uint32_t& cycles);
+	int offset;
+	TraceDqrProfiler::ADDRESS address;
+	uint32_t data[32];
+};
+
+class ProfilerCATrace {
+public:
+	ProfilerCATrace(char* caf_name, TraceDqrProfiler::CATraceType catype);
+	~ProfilerCATrace();
+	TraceDqrProfiler::DQErr consume(uint32_t& caFlags, TraceDqrProfiler::InstType iType, uint32_t& pipeCycles, uint32_t& viStartCycles, uint32_t& viFinishCycles, uint8_t& qDepth, uint8_t& arithDepth, uint8_t& loadDepth, uint8_t& storeDepth);
+
+	TraceDqrProfiler::DQErr rewind();
+	TraceDqrProfiler::ADDRESS getCATraceStartAddr();
+
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+
+private:
+	struct CATraceQItem {
+		uint32_t cycle;
+		uint8_t record;
+		uint8_t qDepth;
+		uint8_t arithInProcess;
+		uint8_t loadInProcess;
+		uint8_t storeInProcess;
+	};
+
+	TraceDqrProfiler::DQErr status;
+
+	TraceDqrProfiler::CATraceType caType;
+	int      caBufferSize;
+	uint8_t* caBuffer;
+	int      caBufferIndex;
+	int      blockRecNum;
+
+	TraceDqrProfiler::ADDRESS startAddr;
+	//uint32_t baseCycles;
+	ProfilerCATraceRec catr;
+	int       traceQSize;
+	int       traceQOut;
+	int       traceQIn;
+	CATraceQItem* caTraceQ;
+
+	int roomQ();
+	TraceDqrProfiler::DQErr packQ();
+
+	TraceDqrProfiler::DQErr addQ(uint32_t data, uint32_t t);
+
+	void dumpCAQ();
+
+	TraceDqrProfiler::DQErr parseNextVectorRecord(int& newDataStart);
+	TraceDqrProfiler::DQErr parseNextCATraceRec(ProfilerCATraceRec& car);
+	TraceDqrProfiler::DQErr dumpCurrentCARecord(int level);
+	TraceDqrProfiler::DQErr consumeCAInstruction(uint32_t& pipe, uint32_t& cycles);
+	TraceDqrProfiler::DQErr consumeCAPipe(int& QStart, uint32_t& cycles, uint32_t& pipe);
+	TraceDqrProfiler::DQErr consumeCAVector(int& QStart, TraceDqrProfiler::CAVectorTraceFlags type, uint32_t& cycles, uint8_t& qInfo, uint8_t& arithInfo, uint8_t& loadInfo, uint8_t& storeInfo);
+};
+
+class ProfilerObjFile {
+public:
+	ProfilerObjFile(char* ef_name, const char* odExe);
+	~ProfilerObjFile();
+	void cleanUp();
+
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+	TraceDqrProfiler::DQErr sourceInfo(TraceDqrProfiler::ADDRESS addr, ProfilerInstruction& instInfo, ProfilerSource& srcInfo);
+	TraceDqrProfiler::DQErr setPathType(TraceDqrProfiler::pathType pt);
+
+	TraceDqrProfiler::DQErr subSrcPath(const char* cutPath, const char* newRoot);
+	TraceDqrProfiler::DQErr parseNLSStrings(TraceDqrProfiler::nlStrings(&nlsStrings)[32]);
+
+	TraceDqrProfiler::DQErr dumpSyms();
+
+private:
+	TraceDqrProfiler::DQErr        status;
+	char* cutPath;
+	char* newRoot;
+	class ElfReader* elfReader;
+	class Disassembler* disassembler;
+};
+
+class TraceProfiler {
+public:
+	TraceProfiler(char* tf_name, char* ef_name, int numAddrBits, uint32_t addrDispFlags, int srcBits, const char* odExe, uint32_t freq = 0);
+	TraceProfiler(char* mf_ame);
+	~TraceProfiler();
+	void cleanUp();
+	static const char* version();
+	TraceDqrProfiler::DQErr setTraceType(TraceDqrProfiler::TraceType tType);
+	TraceDqrProfiler::DQErr setTSSize(int size);
+	TraceDqrProfiler::DQErr setITCPrintOptions(int intFlags, int buffSize, int channel);
+	TraceDqrProfiler::DQErr setPathType(TraceDqrProfiler::pathType pt);
+	TraceDqrProfiler::DQErr setCATraceFile(char* caf_name, TraceDqrProfiler::CATraceType catype);
+	TraceDqrProfiler::DQErr enableCTFConverter(int64_t startTime, char* hostName);
+	TraceDqrProfiler::DQErr enableEventConverter();
+	TraceDqrProfiler::DQErr enablePerfConverter(int perfChannel, uint32_t markerValue);
+
+	TraceDqrProfiler::DQErr subSrcPath(const char* cutPath, const char* newRoot);
+
+	enum TraceFlags {
+		TF_INSTRUCTION = 0x01,
+		TF_ADDRESS = 0x02,
+		TF_DISSASEMBLE = 0x04,
+		TF_TIMESTAMP = 0x08,
+		TF_TRACEINFO = 0x10,
+	};
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+	TraceDqrProfiler::DQErr NextInstruction(ProfilerInstruction** instInfo, ProfilerNexusMessage** msgInfo, ProfilerSource** srcInfo);
+	TraceDqrProfiler::DQErr NextInstruction(ProfilerInstruction* instInfo, ProfilerNexusMessage* msgInfo, ProfilerSource* srcInfo, int* flags);
+	TraceDqrProfiler::DQErr NextInstruction(ProfilerInstruction** instInfo, uint64_t &address_out);
+
+	TraceDqrProfiler::DQErr getTraceFileOffset(int& size, int& offset);
+
+	TraceDqrProfiler::DQErr haveITCPrintData(int numMsgs[DQR_PROFILER_MAXCORES], bool havePrintData[DQR_PROFILER_MAXCORES]);
+	bool        getITCPrintMsg(int core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime);
+	bool        flushITCPrintMsg(int core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime);
+	std::string getITCPrintStr(int core, bool& haveData, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime);
+	std::string flushITCPrintStr(int core, bool& haveData, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime);
+
+	std::string getITCPrintStr(int core, bool& haveData, double& startTime, double& endTime);
+	std::string flushITCPrintStr(int core, bool& haveData, double& startTime, double& endTime);
+
+	//	const char *getSymbolByAddress(TraceDqrProfiler::ADDRESS addr);
+	TraceDqrProfiler::DQErr Disassemble(TraceDqrProfiler::ADDRESS addr);
+	int         getArchSize();
+	int         getAddressSize();
+	void        analyticsToText(char* dst, int dst_len, int detailLevel) { analytics.toText(dst, dst_len, detailLevel); }
+	std::string analyticsToString(int detailLevel) { return analytics.toString(detailLevel); }
+	TraceDqrProfiler::TIMESTAMP processTS(TraceDqrProfiler::tsType tstype, TraceDqrProfiler::TIMESTAMP lastTs, TraceDqrProfiler::TIMESTAMP newTs);
+	int         getITCPrintMask();
+	int         getITCFlushMask();
+	TraceDqrProfiler::DQErr getInstructionByAddress(TraceDqrProfiler::ADDRESS addr, ProfilerInstruction* instInfo, ProfilerSource* srcInfo, int* flags);
+
+	TraceDqrProfiler::DQErr getNumBytesInSWTQ(int& numBytes);
+private:
+	enum state {
+		TRACE_STATE_SYNCCATE,
+		TRACE_STATE_GETFIRSTSYNCMSG,
+		TRACE_STATE_GETMSGWITHCOUNT,
+		TRACE_STATE_RETIREMESSAGE,
+		TRACE_STATE_GETNEXTMSG,
+		TRACE_STATE_GETNEXTINSTRUCTION,
+		TRACE_STATE_DONE,
+		TRACE_STATE_ERROR
+	};
+
+	TraceDqrProfiler::DQErr        status;
+	TraceDqrProfiler::TraceType	   traceType;
+	class SliceFileParser* sfp;
+	class ElfReader* elfReader;
+	class Disassembler* disassembler;
+	class CTFConverter* ctf;
+	class EventConverter* eventConverter;
+	class PerfConverter* perfConverter;
+	char* objdump;
+	char* rtdName;
+	char* efName;
+	char* cutPath;
+	char* newRoot;
+	class ITCPrint* itcPrint;
+	TraceDqrProfiler::nlStrings* nlsStrings;
+	TraceDqrProfiler::ADDRESS      currentAddress[DQR_PROFILER_MAXCORES];
+	TraceDqrProfiler::ADDRESS	   lastFaddr[DQR_PROFILER_MAXCORES];
+	TraceDqrProfiler::TIMESTAMP    lastTime[DQR_PROFILER_MAXCORES];
+	class Count* counts;
+	enum state       state[DQR_PROFILER_MAXCORES];
+	bool             readNewTraceMessage;
+	int              currentCore;
+	int              srcbits;
+	bool             bufferItc;
+	int              enterISR[DQR_PROFILER_MAXCORES];
+
+	int              startMessageNum;
+	int              endMessageNum;
+
+	uint32_t         eventFilterMask;
+
+	int              tsSize;
+	TraceDqrProfiler::pathType pathType;
+
+	uint32_t         freq;
+
+	ProfilerAnalytics        analytics;
+
+	//	need current message number and list of messages??
+
+	ProfilerNexusMessage     nm;
+
+	ProfilerNexusMessage     messageInfo;
+	ProfilerInstruction      instructionInfo;
+	ProfilerSource           sourceInfo;
+
+	int              syncCount;
+	TraceDqrProfiler::ADDRESS caSyncAddr;
+	class ProfilerCATrace* caTrace;
+	TraceDqrProfiler::TIMESTAMP lastCycle[DQR_PROFILER_MAXCORES];
+	int               eCycleCount[DQR_PROFILER_MAXCORES];
+
+	TraceDqrProfiler::DQErr configure(class TraceSettings& settings);
+
+	int decodeInstructionSize(uint32_t inst, int& inst_size);
+	int decodeInstruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+	TraceDqrProfiler::DQErr getCRBRFlags(TraceDqrProfiler::ICTReason cksrc, TraceDqrProfiler::ADDRESS addr, int& crFlag, int& brFlag);
+	TraceDqrProfiler::DQErr nextAddr(TraceDqrProfiler::ADDRESS addr, TraceDqrProfiler::ADDRESS& nextAddr, int& crFlag);
+	TraceDqrProfiler::DQErr nextAddr(int currentCore, TraceDqrProfiler::ADDRESS addr, TraceDqrProfiler::ADDRESS& pc, TraceDqrProfiler::TCode tcode, int& crFlag, TraceDqrProfiler::BranchFlags& brFlag);
+	TraceDqrProfiler::DQErr nextCAAddr(TraceDqrProfiler::ADDRESS& addr, TraceDqrProfiler::ADDRESS& savedAddr);
+
+	TraceDqrProfiler::ADDRESS computeAddress();
+	TraceDqrProfiler::DQErr processTraceMessage(ProfilerNexusMessage& nm, TraceDqrProfiler::ADDRESS& pc, TraceDqrProfiler::ADDRESS& faddr, TraceDqrProfiler::TIMESTAMP& ts, bool& consumed);
+public:
+    // Function to add data to the message queue
+    TraceDqrProfiler::DQErr PushTraceData(uint8_t *p_buff, const uint64_t size);
+    void SetEndOfData();
+};
+
+#endif /* DQR_HPP_ */

--- a/include/dqr_profiler_interface.h
+++ b/include/dqr_profiler_interface.h
@@ -1,0 +1,193 @@
+#pragma once
+/******************************************************************************
+	   Module: dqr_interface.hpp
+	 Engineer: Arjun Suresh
+  Description: Header for Sifive TraceProfiler Decoder Interface Class
+  Date         Initials    Description
+  3-Nov-2022   AS          Initial
+******************************************************************************/
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cstring>
+#include <cstdint>
+#include <thread>
+
+#include "SocketIntf.h"
+#include "dqr_profiler.h"
+//#pragma comment(lib, "Ws2_32.lib")
+
+#define TRANSFER_DATA_OVER_SOCKET 1
+#define WRITE_SEND_DATA_TO_FILE 0
+#define SEND_DATA_FILE_DUMP_PATH "trc_send"
+#define PROFILE_THREAD_BUFFER_SIZE (1024 * 128 * 2)  // 2 MB
+
+using namespace std;
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the DLL_EXPORT
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// DLLEXPORTEDAPI functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+#ifdef DLL_EXPORT
+#ifdef __linux__
+#define DLLEXPORTEDAPI __attribute__ ((visibility ("default")))
+#else
+#define DLLEXPORTEDAPI __declspec(dllexport)
+#endif
+#else
+#ifdef __linux__
+#define DLLEXPORTEDAPI __attribute__ ((visibility ("default")))
+#else
+#define DLLEXPORTEDAPI __declspec(dllimport)
+#endif
+#endif
+
+// Sifive TraceProfiler Decoder Error Types
+typedef enum
+{
+	SIFIVE_TRACE_PROFILER_OK,
+	SIFIVE_TRACE_PROFILER_FILE_NOT_FOUND,
+	SIFIVE_TRACE_PROFILER_CANNOT_OPEN_FILE,
+	SIFIVE_TRACE_PROFILER_INPUT_ARG_NULL,
+	SIFIVE_TRACE_PROFILER_ELF_NULL,
+	SIFIVE_TRACE_PROFILER_MEM_CREATE_ERR,
+	SIFIVE_TRACE_PROFILER_SIM_STATUS_ERROR,
+	SIFIVE_TRACE_PROFILER_VCD_STATUS_ERROR,
+	SIFIVE_TRACE_PROFILER_TRACE_STATUS_ERROR,
+	SIFIVE_TRACE_PROFILER_ERR
+} TySifiveTraceProfileError;
+
+// Sifive TraceProfiler Decoder ProfilerAnalytics Log Level
+typedef enum
+{
+	P_LEVEL_0 = 0,
+	P_LEVEL_1 = 1,
+	P_LEVEL_2 = 2,
+	P_LEVEL_3 = 3
+} TySifiveProfilerMsgLogLevel;
+
+// Sifive TraceProfiler Decoder ProfilerAnalytics Log Level
+typedef enum
+{
+	P_DISABLE = 0,
+	P_SORT_SYSTEM_TOTALS = 1,
+	P_DISPLAY_ANALYTICS_BY_CORE = 2
+} TySifiveProfilerAnalyticsLogLevel;
+
+// Sifive TraceProfiler Decoder Target Arch Size
+typedef enum
+{
+	P_ARCH_GET_FROM_ELF = 0,
+	P_ARCH_32_BIT = 32,
+	P_ARCH_64_BIT = 64
+} TySifiveProfilerTargetArchSize;
+
+// Decoder Config Structure
+struct TProfilerConfig
+{
+	char* trace_filepath = nullptr;
+	char* elf_filepath = nullptr;;
+	char* objdump_path = nullptr;;
+	char* strip_flag = nullptr;
+	char* cutPath = nullptr;
+	char* newRoot = nullptr;
+	bool display_src_info = true;
+	bool display_file_info = true;
+	bool display_dissassembly_info = true;
+	bool display_trace_msg = false;
+	bool display_function_info = true;
+	bool display_call_return_info = true;
+	bool display_branches_info = true;
+	bool display_raw_message_info = false;
+	bool enable_common_trace_format = false;
+	bool enable_profiling_format = false;
+	uint32_t analytics_detail_log_level = TySifiveProfilerAnalyticsLogLevel::P_DISABLE;
+	TraceDqrProfiler::CATraceType cycle_accuracte_type = TraceDqrProfiler::CATRACE_NONE;
+	TraceDqrProfiler::TraceType trace_type = TraceDqrProfiler::TRACETYPE_BTM;
+	uint32_t numAddrBits = 0;
+	uint32_t addrDispFlags = 0;
+	uint32_t archSize = 0;
+	uint32_t trace_msg_log_level = 1;
+	uint32_t timestamp_counter_size_in_bits = 40;
+	uint32_t timestamp_tick_clk_freq_hz = 0;
+	uint32_t src_field_size_bits = 0;
+	TraceDqrProfiler::ITCOptions itc_print_options = TraceDqrProfiler::ITC_OPT_NLS;
+	uint32_t itc_print_channel = 0;
+    uint16_t portno = 6000;
+};
+
+// Interface Class that provides access to the decoder related
+// functionality
+class SifiveProfilerInterface
+{
+private:
+	char* tf_name = nullptr; // TraceProfiler File
+	char* ef_name = nullptr; // ELF File
+	char* od_name = nullptr; // Objdump Path
+	char* sf_name = nullptr; // Simulator File
+	char* ca_name = nullptr; // Cycle Accurate Count File
+	char* pf_name = nullptr; // Properties File
+	char* vf_name = nullptr; // VF File
+	char* strip_flag = nullptr; // Flag to strip path
+	char* cutPath = nullptr; // String to cut from path
+	char* newRoot = nullptr; // String to add to path after cutting cutPath string
+
+	// Decoder Output Info Enable/Disable Flags
+	bool src_flag = true;	      // Output ProfilerSource Info
+	bool file_flag = true;	      // Output File Info
+	bool dasm_flag = true;	      // Output Dissassembly Info
+	bool trace_flag = false; 	  // Output TraceProfiler Messages
+	bool func_flag = true;   	  // Output Function Info
+	bool showCallsReturns = true; // Output Call Return Info
+	bool showBranches = true;     // Output Branch Info
+	bool ctf_flag = false;		  // Output TraceProfiler as Common TraceProfiler Format (Limited Support)
+	bool profile_flag = false;	  // Output PC value with timestamp only
+	int numAddrBits = 0;		  // Display Address as n bits
+	uint32_t addrDispFlags = 0;   // Address display formatting options
+	TraceDqrProfiler::pathType pt = TraceDqrProfiler::PATH_TO_UNIX; // Display format for path info
+	int analytics_detail = TySifiveProfilerAnalyticsLogLevel::P_DISABLE;	// Output ProfilerAnalytics
+	int msgLevel = TySifiveProfilerMsgLogLevel::P_LEVEL_1;			    // Nexus TraceProfiler Msg logging level
+    uint16_t m_port_no = 6000;
+
+	// ITC Print Settings
+	int itcPrintOpts = TraceDqrProfiler::ITC_OPT_NLS; // ITC Print Options
+	int itcPrintChannel = 0;                  // ITC Print Channel
+
+	// Timestamp Info Settings
+	int tssize = 40;	// Timestamp counter size in bits
+	uint32_t freq = 0;	// Timestamp clock frequency
+
+	// Cycle Accurate count and trace type settings
+	TraceDqrProfiler::CATraceType caType = TraceDqrProfiler::CATRACE_NONE;    // Cycle Accurate Count Type
+	TraceDqrProfiler::TraceType traceType = TraceDqrProfiler::TRACETYPE_BTM;  // TraceProfiler Type
+
+	// Arch Size and Src bit Settings
+	int srcbits = 0;												// Size of ProfilerSource bit fields in bits (used for multicore tracing)
+	int archSize = TySifiveProfilerTargetArchSize::P_ARCH_GET_FROM_ELF;	// Target Architecture Size (32/64)
+
+	TraceProfiler* trace = nullptr;
+	FILE* fp = nullptr;
+    SocketIntf *m_client = nullptr;
+    std::thread m_profiling_thread;
+    uint64_t *mp_buffer = nullptr;
+    uint32_t m_thread_idx = 0;
+
+    virtual TySifiveTraceProfileError ProfilingThread();
+    virtual void CleanUp();
+    virtual void WaitforACK();
+public:
+	virtual TySifiveTraceProfileError Configure(const TProfilerConfig& config);
+	virtual ~SifiveProfilerInterface() { CleanUp(); }
+    virtual TySifiveTraceProfileError StartProfilingThread(uint32_t thread_idx);
+    virtual TySifiveTraceProfileError PushTraceData(uint8_t *p_buff, const uint64_t &size);
+    virtual void WaitForProfilerCompletion();
+    virtual void SetEndOfData();
+};
+
+// Function pointer typedef
+typedef SifiveProfilerInterface* (*fpGetSifiveProfilerInterface)();
+
+// Exported C API function that returns the pointer to the Sifive decoder class instance
+extern "C" DLLEXPORTEDAPI SifiveProfilerInterface * GetSifiveProfilerInterface();

--- a/include/dqr_trace_profiler.h
+++ b/include/dqr_trace_profiler.h
@@ -1,0 +1,676 @@
+/* Copyright 2022 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef DQR_TRACE_PROFILER_HPP_
+#define DQR_TRACE_PROFILER_HPP_
+
+// private definitions
+#include<stdint.h>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cstring>
+#include <cstdint>
+#include <cassert>
+#include <fcntl.h>
+#include <cctype>    // std::tolower
+#include <algorithm> // std::equal
+#include <deque>
+#include <mutex>
+//#include <unistd.h>
+#ifdef WINDOWS
+#include<windows.h>
+#endif
+int32_t ichar_equals(char a, char b);
+int32_t strcasecmp(const std::string& a, const std::string& b);
+
+
+#ifdef DO_TIMES
+class Timer {
+public:
+	Timer();
+	~Timer();
+
+	double start();
+	double etime();
+
+private:
+	double startTime;
+};
+#endif // DO_TIMES
+
+void sanePath(TraceDqrProfiler::pathType pt, const char* src, char* dst);
+
+class cachedInstInfo {
+public:
+	cachedInstInfo(const char* file, int cutPathIndex, const char* func, int linenum, const char* lineTxt, const char* instText, TraceDqrProfiler::RV_INST inst, int instSize, const char* addresslabel, int addresslabeloffset);
+	~cachedInstInfo();
+
+	void dump();
+
+	const char* filename;
+	int         cutPathIndex;
+	const char* functionname;
+	int         linenumber;
+	const char* lineptr;
+
+	TraceDqrProfiler::RV_INST instruction;
+	int               instsize;
+
+	char* instructionText;
+
+	const char* addressLabel;
+	int               addressLabelOffset;
+};
+
+// class Section: work with elf file sections
+
+class SrcFile {
+public:
+	SrcFile(char* fName, SrcFile* nxt);
+	~SrcFile();
+
+	class SrcFile* next;
+	char* file;
+};
+
+class SrcFileRoot {
+public:
+	SrcFileRoot();
+	~SrcFileRoot();
+
+	char* addFile(char* fName);
+	void dump();
+
+private:
+	SrcFile* fileRoot;
+};
+
+class Section {
+public:
+
+	enum {
+		sect_CONTENTS = 1 << 0,
+		sect_ALLOC = 1 << 1,
+		sect_LOAD = 1 << 2,
+		sect_READONLY = 1 << 3,
+		sect_DATA = 1 << 4,
+		sect_CODE = 1 << 5,
+		sect_THREADLOCAL = 1 << 6,
+		sect_DEBUGGING = 1 << 7,
+		sect_OCTETS = 1 << 8
+	};
+
+	Section();
+	~Section();
+
+	Section* getSectionByAddress(TraceDqrProfiler::ADDRESS addr);
+	Section* getSectionByName(char* secName);
+
+	cachedInstInfo* setCachedInfo(TraceDqrProfiler::ADDRESS addr, const char* file, int cutPathIndex, const char* func, int linenum, const char* lineTxt, const char* instTxt, TraceDqrProfiler::RV_INST inst, int instSize, const char* addresslabel, int addresslabeloffset);
+	cachedInstInfo* getCachedInfo(TraceDqrProfiler::ADDRESS addr);
+
+	void dump();
+
+	Section* next;
+	char         name[256];
+	TraceDqrProfiler::ADDRESS startAddr;
+	TraceDqrProfiler::ADDRESS endAddr;
+	uint32_t     flags;
+	uint32_t     size;	// size of section
+	uint32_t     offset; // offset of section in elf file
+	uint32_t     align;
+	uint16_t* code;
+	char** fName; // file name - array of pointers
+	uint32_t* line;  // line number
+	char** diss;  // disassembly text - array of pointers
+
+	cachedInstInfo** cachedInfo; // array of pointers
+};
+
+// class fileReader: Helper class to handler list of source code files
+
+class fileReader {
+public:
+	struct funcList {
+		funcList* next;
+		char* func;
+	};
+	struct fileList {
+		fileList* next;
+		char* name;
+		int           cutPathIndex;
+		funcList* funcs;
+		unsigned int  lineCount;
+		char** lines;
+	};
+
+	fileReader(/*paths?*/);
+	~fileReader();
+
+	TraceDqrProfiler::DQErr subSrcPath(const char* cutPath, const char* newRoot);
+	fileList* findFile(const char* file);
+
+private:
+	char* cutPath;
+	char* newRoot;
+
+	fileList* readFile(const char* file);
+
+	fileList* lastFile;
+	fileList* files;
+};
+
+// class Symtab: Interface class between bfd symbols and what is needed for dqr
+
+struct Sym {
+	enum {
+		symNone = 0,
+		symLocal = 1 << 0,
+		symGlobal = 1 << 1,
+		symWeak = 1 << 2,
+		symConstructor = 1 << 3,
+		symIndirect = 1 << 4,
+		symIndirectFunc = 1 << 5,
+		symDebug = 1 << 6,
+		symDynamic = 1 << 7,
+		symFunc = 1 << 8,
+		symFile = 1 << 9,
+		symObj = 1 << 10
+	};
+
+	struct Sym* next;
+	char* name;
+	uint32_t flags;
+	class Section* section;
+	uint64_t address;
+	uint64_t size;
+	struct Sym* srcFile;
+};
+
+class Symtab {
+public:
+	Symtab(Sym* syms);
+	~Symtab();
+	TraceDqrProfiler::DQErr lookupSymbolByAddress(TraceDqrProfiler::ADDRESS addr, Sym*& sym);
+	void         dump();
+
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+
+private:
+	TraceDqrProfiler::DQErr status;
+
+	TraceDqrProfiler::ADDRESS cachedSymAddr;
+	int cachedSymSize;
+	int cachedSymIndex;
+
+	long      numSyms;
+	Sym* symLst;
+	Sym** symPtrArray;
+
+	TraceDqrProfiler::DQErr fixupFunctionSizes();
+};
+
+// find : Interface class between dqr and bfd
+
+class ObjDump {
+public:
+	ObjDump(const char* elfName, const char* objDumpPath, int& archSize, Section*& codeSectionLst, Sym*& syms, SrcFileRoot& srcFileRoot);
+	~ObjDump();
+
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+
+private:
+	enum objDumpTokenType {
+		odtt_error,
+		odtt_eol,
+		odtt_eof,
+		odtt_colon,
+		odtt_lt,
+		odtt_gt,
+		odtt_lp,
+		odtt_rp,
+		odtt_comma,
+		odtt_string,
+		odtt_number,
+	};
+
+	enum elfType {
+		elfType_unknown,
+		elfType_64_little,
+		elfType_32_little,
+	};
+
+	enum line_t {
+		line_t_label,
+		line_t_diss,
+		line_t_path,
+		line_t_func,
+	};
+
+	TraceDqrProfiler::DQErr status;
+
+	int stdoutPipe;
+	FILE* fpipe;
+
+	bool pipeEOF;
+	char pipeBuffer[2048];
+	int  pipeIndex = 0;
+	int  endOfBuffer = 0;
+
+	int32_t objdumpPid;
+#ifdef WINDOWS
+	HANDLE hStdOutPipeRead = NULL;
+	HANDLE hStdOutPipeWrite = NULL;
+	PROCESS_INFORMATION pi;
+#endif
+	TraceDqrProfiler::DQErr execObjDump(const char* elfName, const char* objdumpPath);
+	TraceDqrProfiler::DQErr fillPipeBuffer();
+	objDumpTokenType getNextLex(char* lex);
+	bool isWSLookahead();
+	bool isStringAHexNumber(char* s, uint64_t& n);
+	bool isStringADecNumber(char* s, uint64_t& n);
+	objDumpTokenType getRestOfLine(char* lex);
+	TraceDqrProfiler::DQErr parseSection(objDumpTokenType& nextType, char* nextLex, Section*& codeSection);
+	TraceDqrProfiler::DQErr parseSectionList(objDumpTokenType& nextType, char* nextLex, Section*& codeSectionLst);
+	TraceDqrProfiler::DQErr parseFileLine(uint32_t& line);
+	TraceDqrProfiler::DQErr parseFuncName();
+	TraceDqrProfiler::DQErr parseFileOrLabelOrDisassembly(line_t& lineType, char* text, int& length, uint32_t& value);
+	TraceDqrProfiler::DQErr parseDisassembly(bool& isLabel, int& instSize, uint32_t& inst, char* disassembly);
+	TraceDqrProfiler::DQErr parseDisassemblyList(objDumpTokenType& nextType, char* nextLex, Section* codeSectionLst, SrcFileRoot& srcFileRoot);
+	TraceDqrProfiler::DQErr parseFixedField(uint32_t& flags);
+	TraceDqrProfiler::DQErr parseSymbol(bool& haveSym, char* secName, char* symName, uint32_t& symFlags, uint64_t& symSize);
+	TraceDqrProfiler::DQErr parseSymbolTable(objDumpTokenType& nextType, char* nextLex, Sym*& syms, Section*& codeSectionLst);
+	TraceDqrProfiler::DQErr parseElfName(char* elfName, enum elfType& et);
+	TraceDqrProfiler::DQErr parseObjdump(int& archSize, Section*& codeSectionLst, Sym*& syms, SrcFileRoot& srcFileRoot);
+};
+
+class ElfReader {
+public:
+	ElfReader(const char* elfname, const char* odExe);
+	~ElfReader();
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+	TraceDqrProfiler::DQErr getInstructionByAddress(TraceDqrProfiler::ADDRESS addr, TraceDqrProfiler::RV_INST& inst);
+	Symtab* getSymtab();
+	Section* getSections() { return codeSectionLst; }
+	int        getArchSize() { return archSize; }
+	int        getBitsPerAddress() { return bitsPerAddress; }
+
+	TraceDqrProfiler::DQErr parseNLSStrings(TraceDqrProfiler::nlStrings* nlsStrings);
+
+	TraceDqrProfiler::DQErr dumpSyms();
+
+private:
+	TraceDqrProfiler::DQErr  status;
+	char* elfName;
+	int         archSize;
+	int         bitsPerAddress;
+	Section* codeSectionLst;
+	Symtab* symtab;
+	SrcFileRoot srcFileRoot;
+
+	TraceDqrProfiler::DQErr fixupSourceFiles(Section* sections, Sym* syms);
+};
+
+class TsList {
+public:
+	TsList();
+	~TsList();
+
+	class TsList* prev;
+	class TsList* next;
+	bool terminated;
+	TraceDqrProfiler::TIMESTAMP startTime;
+	TraceDqrProfiler::TIMESTAMP endTime;
+	char* message;
+};
+
+class ITCPrint {
+public:
+	ITCPrint(int itcPrintOpts, int numCores, int buffSize, int channel, TraceDqrProfiler::nlStrings* nlsStrings);
+	~ITCPrint();
+	bool print(uint8_t core, uint32_t address, uint32_t data);
+	bool print(uint8_t core, uint32_t address, uint32_t data, TraceDqrProfiler::TIMESTAMP tstamp);
+	void haveITCPrintData(int numMsgs[DQR_PROFILER_MAXCORES], bool havePrintData[DQR_PROFILER_MAXCORES]);
+	bool getITCPrintMsg(uint8_t core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime);
+	bool flushITCPrintMsg(uint8_t core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime);
+	bool getITCPrintStr(uint8_t core, std::string& s, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime);
+	bool flushITCPrintStr(uint8_t core, std::string& s, TraceDqrProfiler::TIMESTAMP& starTime, TraceDqrProfiler::TIMESTAMP& endTime);
+	int  getITCPrintMask();
+	int  getITCFlushMask();
+	bool haveITCPrintMsgs();
+
+private:
+	int  roomInITCPrintQ(uint8_t core);
+	TsList* consumeTerminatedTsList(int core);
+	TsList* consumeOldestTsList(int core);
+
+	int itcOptFlags;
+	int numCores;
+	int buffSize;
+	int printChannel;
+	TraceDqrProfiler::nlStrings* nlsStrings;
+	char** pbuff;
+	int* pbi;
+	int* pbo;
+	int* numMsgs;
+	class TsList** tsList;
+	class TsList* freeList;
+};
+
+// class SliceFileParser: Class to parse binary or ascii nexus messages into a ProfilerNexusMessage object
+class SliceFileParser {
+public:
+	SliceFileParser(char* filename, int srcBits);
+	~SliceFileParser();
+	TraceDqrProfiler::DQErr readNextTraceMsg(ProfilerNexusMessage& nm, class ProfilerAnalytics& analytics, bool& haveMsg);
+	TraceDqrProfiler::DQErr getFileOffset(int& size, int& offset);
+
+	TraceDqrProfiler::DQErr getErr() { return status; };
+	void       dump();
+
+	TraceDqrProfiler::DQErr getNumBytesInSWTQ(int& numBytes);
+    // Function to add data to the message queue
+    TraceDqrProfiler::DQErr PushTraceData(uint8_t *p_buff, const uint64_t size)
+    {
+        if (!p_buff)
+        {
+            return TraceDqrProfiler::DQERR_ERR;
+        }
+        std::lock_guard<std::mutex> msg_queue_guard(m_msg_queue_mutex);
+        m_msg_queue.insert(m_msg_queue.end(), p_buff, p_buff + size);
+        return TraceDqrProfiler::DQERR_OK;
+    }
+    // Function to set end of data
+    void SetEndOfData()
+    {
+        std::lock_guard<std::mutex> msg_eod_guard(m_end_of_data_mutex);
+        m_end_of_data = true;
+    }
+private:
+	TraceDqrProfiler::DQErr status;
+
+	// add other counts for each message type
+
+	int           srcbits;
+	std::ifstream tf;
+	uint8_t* m_string;
+	uint64_t m_size;
+	uint64_t m_idx;
+	int           tfSize;
+	int           SWTsock;
+	int           bitIndex;
+	int           msgSlices;
+	uint32_t      msgOffset;
+	int           pendingMsgIndex;
+	uint8_t       msg[64];
+	bool          eom;
+
+	int           bufferInIndex;
+	int           bufferOutIndex;
+	uint8_t       sockBuffer[2048];
+    // Mutex to sync m_msg_queue 
+    std::mutex m_msg_queue_mutex;
+    // Mutex to sync m_end_of_data 
+    std::mutex m_end_of_data_mutex;
+    std::deque<uint8_t> m_msg_queue;
+    bool m_end_of_data;
+
+	TraceDqrProfiler::DQErr readBinaryMsg(bool& haveMsg);
+	TraceDqrProfiler::DQErr bufferSWT();
+	TraceDqrProfiler::DQErr readNextByte(uint8_t* byte);
+	TraceDqrProfiler::DQErr parseVarField(uint64_t* val, int* width);
+	TraceDqrProfiler::DQErr parseFixedField(int width, uint64_t* val);
+	TraceDqrProfiler::DQErr parseDirectBranch(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseIndirectBranch(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseDirectBranchWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseIndirectBranchWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseSync(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseCorrelation(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseAuxAccessWrite(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseDataAcquisition(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseOwnershipTrace(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseError(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseIndirectHistory(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseIndirectHistoryWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseResourceFull(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseICT(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+	TraceDqrProfiler::DQErr parseICTWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics);
+};
+#if 1
+class propertiesParser {
+public:
+	propertiesParser(const char* srcData);
+	~propertiesParser();
+
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+
+	void            rewind();
+	TraceDqrProfiler::DQErr getNextProperty(char** name, char** value);
+
+private:
+	TraceDqrProfiler::DQErr status;
+
+	struct line {
+		char* name;
+		char* value;
+		char* line;
+	};
+
+	int   size;
+	int   numLines;
+	int   nextLine;
+	line* lines;
+	char* propertiesBuff;
+
+	TraceDqrProfiler::DQErr getNextToken(char* inputText, int& startIndex, int& endIndex);
+};
+
+// class TraceSettings. Used to initialize trace objects
+
+class TraceSettings {
+public:
+	TraceSettings();
+	~TraceSettings();
+
+	TraceDqrProfiler::DQErr addSettings(propertiesParser* properties);
+
+	TraceDqrProfiler::DQErr propertyToTFName(const char* value);
+	TraceDqrProfiler::DQErr propertyToEFName(const char* value);
+	TraceDqrProfiler::DQErr propertyToPFName(const char* value);
+	TraceDqrProfiler::DQErr propertyToSrcBits(const char* value);
+	TraceDqrProfiler::DQErr propertyToNumAddrBits(const char* value);
+	TraceDqrProfiler::DQErr propertyToITCPrintOpts(const char* value);
+	TraceDqrProfiler::DQErr propertyToITCPrintBufferSize(const char* value);
+	TraceDqrProfiler::DQErr propertyToITCPrintChannel(const char* value);
+	TraceDqrProfiler::DQErr propertyToITCPerfEnable(const char* value);
+	TraceDqrProfiler::DQErr propertyToITCPerfChannel(const char* value);
+	TraceDqrProfiler::DQErr propertyToITCPerfMarkerValue(const char* value);
+	TraceDqrProfiler::DQErr propertyToSrcRoot(const char* value);
+	TraceDqrProfiler::DQErr propertyToSrcCutPath(const char* value);
+	TraceDqrProfiler::DQErr propertyToCAName(const char* value);
+	TraceDqrProfiler::DQErr propertyToCAType(const char* value);
+	TraceDqrProfiler::DQErr propertyToPathType(const char* value);
+	TraceDqrProfiler::DQErr propertyToFreq(const char* value);
+	TraceDqrProfiler::DQErr propertyToTSSize(const char* value);
+	TraceDqrProfiler::DQErr propertyToAddrDispFlags(const char* value);
+	TraceDqrProfiler::DQErr propertyToCTFEnable(const char* value);
+	TraceDqrProfiler::DQErr propertyToEventConversionEnable(const char* value);
+	TraceDqrProfiler::DQErr propertyToStartTime(const char* value);
+	TraceDqrProfiler::DQErr propertyToHostName(const char* value);
+	TraceDqrProfiler::DQErr propertyToObjdumpName(const char* value);
+
+	char* odName;
+	char* tfName;
+	char* efName;
+	char* caName;
+	char* pfName;
+	TraceDqrProfiler::CATraceType caType;
+	int srcBits;
+	int numAddrBits;
+	int itcPrintOpts;
+	int itcPrintBufferSize;
+	int itcPrintChannel;
+	char* cutPath;
+	char* srcRoot;
+	TraceDqrProfiler::pathType pathType;
+	uint32_t freq;
+	uint32_t addrDispFlags;
+	int64_t  startTime;
+	int tsSize;
+	bool CTFConversion;
+	bool eventConversionEnable;
+	char* hostName;
+	bool filterControlEvents;
+
+	bool itcPerfEnable;
+	int itcPerfChannel;
+	uint32_t itcPerfMarkerValue;
+
+private:
+	TraceDqrProfiler::DQErr propertyToBool(const char* src, bool& value);
+};
+#endif
+// class Disassembler: class to help in the dissasemblhy of instrucitons
+
+class Disassembler {
+public:
+	Disassembler(Symtab* stp, Section* sp, int archsize);
+	~Disassembler();
+
+	TraceDqrProfiler::DQErr disassemble(TraceDqrProfiler::ADDRESS addr);
+
+	TraceDqrProfiler::DQErr getSrcLines(TraceDqrProfiler::ADDRESS addr, const char** filename, int* cutPathIndex, const char** functionname, unsigned int* linenumber, const char** lineptr);
+
+	TraceDqrProfiler::DQErr getFunctionName(TraceDqrProfiler::ADDRESS addr, const char*& function, int& offset);
+
+	static TraceDqrProfiler::DQErr   decodeInstructionSize(uint32_t inst, int& inst_size);
+	static int   decodeInstruction(uint32_t instruction, int archSize, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+
+	ProfilerInstruction getInstructionInfo() { return instruction; }
+	ProfilerSource      getSourceInfo() { return source; }
+
+	TraceDqrProfiler::DQErr setPathType(TraceDqrProfiler::pathType pt);
+	TraceDqrProfiler::DQErr subSrcPath(const char* cutPath, const char* newRoot);
+
+	TraceDqrProfiler::DQErr getStatus() { return status; }
+
+private:
+	TraceDqrProfiler::DQErr   status;
+
+	int               archSize;
+
+	Section* sectionLst;		// owned by elfReader - don't delete
+	Symtab* symtab;			// owned by elfReader - don't delete
+
+	// cached section information
+
+	TraceDqrProfiler::ADDRESS cachedAddr;
+	Section* cachedSecPtr;
+	int               cachedIndex;
+
+	ProfilerInstruction instruction;
+	ProfilerSource      source;
+
+	class fileReader* fileReader;
+
+	TraceDqrProfiler::pathType pType;
+
+	TraceDqrProfiler::DQErr getDissasembly(TraceDqrProfiler::ADDRESS addr, char*& dissText);
+	TraceDqrProfiler::DQErr cacheSrcInfo(TraceDqrProfiler::ADDRESS addr);
+
+	TraceDqrProfiler::DQErr lookupInstructionByAddress(TraceDqrProfiler::ADDRESS addr, uint32_t& ins, int& insSize);
+	TraceDqrProfiler::DQErr findNearestLine(TraceDqrProfiler::ADDRESS addr, const char*& file, int& line);
+
+	TraceDqrProfiler::DQErr getInstruction(TraceDqrProfiler::ADDRESS addr, ProfilerInstruction& instruction);
+
+	// need to make all the decode function static. Might need to move them to public?
+
+	static int decodeRV32Q0Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+	static int decodeRV32Q1Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+	static int decodeRV32Q2Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+	static int decodeRV32Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+
+	static int decodeRV64Q0Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+	static int decodeRV64Q1Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+	static int decodeRV64Q2Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+	static int decodeRV64Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch);
+};
+
+class AddrStack {
+public:
+	AddrStack(int size = 2048);
+	~AddrStack();
+	void reset();
+	int push(TraceDqrProfiler::ADDRESS addr);
+	TraceDqrProfiler::ADDRESS pop();
+	int getNumOnStack() { return stackSize - sp; }
+
+private:
+	int stackSize;
+	int sp;
+	TraceDqrProfiler::ADDRESS* stack;
+};
+
+class Count {
+public:
+	Count();
+	~Count();
+
+	void resetCounts(int core);
+
+	TraceDqrProfiler::CountType getCurrentCountType(int core);
+	TraceDqrProfiler::DQErr setICnt(int core, int count);
+	TraceDqrProfiler::DQErr setHistory(int core, uint64_t hist);
+	TraceDqrProfiler::DQErr setHistory(int core, uint64_t hist, int count);
+	TraceDqrProfiler::DQErr setTakenCount(int core, int takenCnt);
+	TraceDqrProfiler::DQErr setNotTakenCount(int core, int notTakenCnt);
+	TraceDqrProfiler::DQErr setCounts(ProfilerNexusMessage* nm);
+	int consumeICnt(int core, int numToConsume);
+	int consumeHistory(int core, bool& taken);
+	int consumeTakenCount(int core);
+	int consumeNotTakenCount(int core);
+
+	int getICnt(int core) { return i_cnt[core]; }
+	uint32_t getHistory(int core) { return history[core]; }
+	int getNumHistoryBits(int core) { return histBit[core]; }
+	uint32_t getTakenCount(int core) { return takenCount[core]; }
+	uint32_t getNotTakenCount(int core) { return notTakenCount[core]; }
+	uint32_t isTaken(int core) { return (history[core] & (1 << histBit[core])) != 0; }
+
+	int push(int core, TraceDqrProfiler::ADDRESS addr) { return stack[core].push(addr); }
+	TraceDqrProfiler::ADDRESS pop(int core) { return stack[core].pop(); }
+	void resetStack(int core) { stack[core].reset(); }
+	int getNumOnStack(int core) { return stack[core].getNumOnStack(); }
+
+
+	void dumpCounts(int core);
+
+	//	int getICnt(int core);
+	//	int adjustICnt(int core,int delta);
+	//	bool isHistory(int core);
+	//	bool takenHistory(int core);
+
+private:
+	int i_cnt[DQR_PROFILER_MAXCORES];
+	uint64_t history[DQR_PROFILER_MAXCORES];
+	int histBit[DQR_PROFILER_MAXCORES];
+	int takenCount[DQR_PROFILER_MAXCORES];
+	int notTakenCount[DQR_PROFILER_MAXCORES];
+	AddrStack stack[DQR_PROFILER_MAXCORES];
+};
+
+#endif /* TRACE_HPP_ */
+
+
+// Improvements:
+//
+// Disassembler class:
+//  Should be able to creat disassembler object without elf file
+//  Should have a diasassemble method that takes an address and an instruciotn, not just an address
+//  Should be able us use a block of memory for the code, not from an elf file
+//  Use new methods to cleanup verilator nextInstruction()
+
+// move some stuff in instruction object to a separate object pointed to from instruciton object so that coppies
+// of the object don't need to copy it all (regfile is an example). Create accessor method to get. Destructor should
+// delete all

--- a/include/linuxutils.h
+++ b/include/linuxutils.h
@@ -1,0 +1,40 @@
+/******************************************************************************
+       Module: linuxutils.h
+     Engineer: SVimalraj Rajasekharan
+  Description: Class for parsing command line arguemnts
+
+  Date           Initials    Description
+  30-Nov-2023    VR          Initial
+  ****************************************************************************/
+#pragma once
+#include <stdint.h>
+#include <stdio.h>
+#ifdef __LINUX
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <pthread.h>
+#endif
+
+#ifndef SOCKET_ERROR
+#define SOCKET_ERROR    (uint32_t)(-1)
+#endif
+
+typedef int32_t SOCKET;
+
+typedef struct 
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    uint8_t triggered;
+} linuxevent;
+
+
+void linuxevent_init(linuxevent *ev);
+void linuxevent_trigger(linuxevent *ev);
+void linuxevent_wait(linuxevent *ev);
+void linuxevent_destroy(linuxevent *ev);
+
+int closesocket(SOCKET socketfd);
+int CreateThread(void *(*start_routine)(void *), void *arg);

--- a/include/unistd_profiler.h
+++ b/include/unistd_profiler.h
@@ -1,0 +1,66 @@
+#ifdef __linux__
+#include <unistd.h>
+#define _open open
+#define _read read
+#define _write write
+#define _close close
+#else
+#pragma once
+#ifndef _UNISTD_H
+#define _UNISTD_H    1
+
+/* This is intended as a drop-in replacement for unistd.h on Windows.
+ * Please add functionality as needed.
+ * https://stackoverflow.com/a/826027/1202830
+ */
+
+#include <stdlib.h>
+#include <io.h>
+//#include <getopt.h> /* getopt at: https://gist.github.com/ashelly/7776712 */
+#include <process.h> /* for getpid() and the exec..() family */
+#include <direct.h> /* for _getcwd() and _chdir() */
+
+#define srandom srand
+#define random rand
+
+ /* Values for the second argument to access.
+	These may be OR'd together.  */
+#define R_OK    4       /* Test for read permission.  */
+#define W_OK    2       /* Test for write permission.  */
+#define X_OK    0       /* execute permission - unsupported in windows*/
+#define F_OK    0       /* Test for existence.  */
+
+#define access _access
+#define dup2 _dup2
+#define execve _execve
+#define ftruncate _chsize
+#define unlink _unlink
+#define fileno _fileno
+#define getcwd _getcwd
+#define chdir _chdir
+#define isatty _isatty
+#define lseek _lseek
+#
+/* read, write, and close are NOT being #defined here, because while there are file handle specific versions for Windows, they probably don't work for sockets. You need to look at your app and consider whether to call e.g. closesocket(). */
+
+#ifdef _WIN64
+#define ssize_t __int64
+#else
+#define ssize_t long
+#endif
+
+#define STDIN_FILENO 0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+/* should be in some equivalent to <sys/types.h> */
+//typedef __int8            int8_t;
+//typedef __int16           int16_t;
+//typedef __int32           int32_t;
+//typedef __int64           int64_t;
+//typedef unsigned __int8   uint8_t;
+//typedef unsigned __int16  uint16_t;
+//typedef unsigned __int32  uint32_t;
+//typedef unsigned __int64  uint64_t;
+
+#endif /* unistd.h  */
+#endif

--- a/project/linux/makefile
+++ b/project/linux/makefile
@@ -1,0 +1,73 @@
+# Make command to use for dependencies
+MAKE=make
+CC=g++
+
+# If no configuration is specified, "Release" will be used
+ifndef "CFG"
+CFG=Release
+endif
+
+COMPILE_INC=-I../../include
+COMPILE_DEFS=-D__LINUX
+COMPILE_FLAGS=-std=c++0x -Wall -fpermissive -Wno-unknown-pragmas -fstack-protector-strong -fPIC -MMD -shared -fvisibility=hidden -c -m64
+JNI_INC=
+JNI_INC_MD=
+LINK_FLAGS=-std=c++0x -Wall -shared -fvisibility=hidden -z noexecstack -Wl,-z,relro,-z,now,-z,defs,-soname,"$(OUTFILE)" -o"$(OUTFILE)" -Xlinker -Bsymbolic
+LINK_LIBS=-ldl -lpthread
+
+ifeq "$(ARCH)" "64"
+COMPILE_FLAGS+=-m64
+LINK_FLAGS+=
+else ifeq "$(ARCH)" "32"
+COMPILE_FLAGS+=-m32
+LINK_FLAGS+=
+endif
+
+ifeq "$(CFG)" "Release"
+OUTDIR=Release
+COMPILE_FLAGS+=-D_LOGGING_ENABLED -D_LOGGING_LEVEL=3
+else ifeq "$(CFG)" "Debug"
+OUTDIR=Debug
+COMPILE_FLAGS+=-g -D_LOGGING_ENABLED -D_LOGGING_LEVEL=0
+endif
+
+COMPILE=$(CC) $(COMPILE_FLAGS) $(COMPILE_DEFS) $(COMPILE_INC)  $(JNI_INC) $(JNI_INC_MD) -o "$(OUTDIR)/$(*F).o" "$<"
+LINK=$(CC) $(LINK_FLAGS) $(ALL_OBJS) $(LINK_LIBS)
+OUTFILE=$(OUTDIR)/libdqr_profiler.so
+
+ALL_OBJS=	$(OUTDIR)/dqr_profiler_interface.o \
+            $(OUTDIR)/dqr_profiler.o \
+			$(OUTDIR)/dqr_trace_profiler.o \
+			$(OUTDIR)/SocketIntf.o \
+			$(OUTDIR)/PacketFormat.o \
+			$(OUTDIR)/linuxutils.o
+
+# Pattern rules
+$(OUTDIR)/%.o : ../../src/%.cpp
+	@echo "Compiling $<"
+	@$(COMPILE)
+
+# Build rules
+all: $(OUTFILE)
+
+$(OUTFILE): $(OUTDIR) $(ALL_OBJS)
+	@echo ""
+	@echo "Linking $(OUTFILE)"
+	@$(LINK)
+	@echo ""
+
+$(OUTDIR):
+	@mkdir -p "$(OUTDIR)"
+
+# Rebuild this project
+rebuild: cleanall all
+
+# Clean this project
+clean:
+	@rm -rf $(OUTDIR)
+	@echo "Cleaned all"
+
+# Clean this project and all dependencies
+cleanall: clean
+
+-include $(ALL_OBJS:.o=.d)

--- a/project/win/profiler/profiler.sln
+++ b/project/win/profiler/profiler.sln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33829.357
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "profiler", "profiler.vcxproj", "{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Debug-DLL|x64 = Debug-DLL|x64
+		Debug-DLL|x86 = Debug-DLL|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		Release-DLL|x64 = Release-DLL|x64
+		Release-DLL|x86 = Release-DLL|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug|x64.ActiveCfg = Debug-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug|x64.Build.0 = Debug-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug|x86.ActiveCfg = Debug|Win32
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug|x86.Build.0 = Debug|Win32
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug-DLL|x64.ActiveCfg = Debug-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug-DLL|x64.Build.0 = Debug-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug-DLL|x86.ActiveCfg = Debug-DLL|Win32
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Debug-DLL|x86.Build.0 = Debug-DLL|Win32
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Release|x64.ActiveCfg = Release-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Release|x64.Build.0 = Release-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Release|x86.ActiveCfg = Release|Win32
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Release|x86.Build.0 = Release|Win32
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Release-DLL|x64.ActiveCfg = Release-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Release-DLL|x64.Build.0 = Release-DLL|x64
+		{CDB5DEE6-CAE3-4AEB-A95D-0350CD5117B3}.Release-DLL|x86.ActiveCfg = Release-DLL|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {04859222-33E9-4BB6-8835-7FE5B44C617D}
+	EndGlobalSection
+EndGlobal

--- a/project/win/profiler/profiler.vcxproj
+++ b/project/win/profiler/profiler.vcxproj
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug-DLL|Win32">
+      <Configuration>Debug-DLL</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-DLL|x64">
+      <Configuration>Debug-DLL</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-DLL|Win32">
+      <Configuration>Release-DLL</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-DLL|x64">
+      <Configuration>Release-DLL</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\dqr_profiler.cpp" />
+    <ClCompile Include="..\..\..\src\dqr_profiler_interface.cpp" />
+    <ClCompile Include="..\..\..\src\dqr_trace_profiler.cpp" />
+    <ClCompile Include="..\..\..\src\PacketFormat.cpp" />
+    <ClCompile Include="..\..\..\src\SocketIntf.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\include\dqr_profiler.h" />
+    <ClInclude Include="..\..\..\include\dqr_profiler_interface.h" />
+    <ClInclude Include="..\..\..\include\dqr_trace_profiler.h" />
+    <ClInclude Include="..\..\..\include\unistd_profiler.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{cdb5dee6-cae3-4aeb-a95d-0350cd5117b3}</ProjectGuid>
+    <RootNamespace>profiler</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>profiler</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|Win32'">
+    <TargetName>dqr_profiler</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|x64'">
+    <TargetName>dqr_profiler</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|Win32'">
+    <TargetName>dqr_profiler</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|x64'">
+    <TargetName>dqr_profiler</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <Optimization>MaxSpeed</Optimization>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-DLL|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <Optimization>MaxSpeed</Optimization>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>../../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/project/win/profiler/profiler.vcxproj.filters
+++ b/project/win/profiler/profiler.vcxproj.filters
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\dqr_profiler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\dqr_profiler_interface.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\dqr_trace_profiler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\PacketFormat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\SocketIntf.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\include\dqr_profiler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\dqr_profiler_interface.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\dqr_trace_profiler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\unistd_profiler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/project/win/profiler/profiler.vcxproj.user
+++ b/project/win/profiler/profiler.vcxproj.user
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|Win32'">
+    <LocalDebuggerCommandArguments />
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-DLL|x64'">
+    <LocalDebuggerCommandArguments />
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/src/PacketFormat.cpp
+++ b/src/PacketFormat.cpp
@@ -1,0 +1,305 @@
+/******************************************************************************
+       Module: PICP.cpp
+     Engineer: Vimalraj Rajasekharan
+  Description: Class to define and manage Probe server packet formatting
+  Date           Initials    Description
+  01-Dec-2023    VR          Initial
+******************************************************************************/
+#include <stdio.h>
+#include <string.h> 
+#include "PacketFormat.h"
+#ifdef __linux__
+#include <arpa/inet.h>
+#endif
+
+/****************************************************************************
+     Function: PICP
+     Engineer: Vimalraj Rajasekharan
+        Input: ulMaxDataSize - Maximum possible data size
+               eType - Command type
+               eCmd - Command value
+       Output: None
+       Return: None
+  Description: Constructor
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+PICP::PICP(uint32_t ulMaxDataSize, PICPType eType, uint32_t eCmd)
+    : m_bIsValid(false)
+    , m_bIsCreated(true)
+    , m_pucBuffer(NULL)
+    , m_ulCurIndex(0)
+    , m_eType(eType)
+    , m_eCommand(eCmd)
+    , m_ulMaxDataSize(ulMaxDataSize)
+    , m_ulCRC(0xDEADC0DE)
+{
+    m_pucBuffer = new uint8_t[sizeof(PICPHeader) + m_ulMaxDataSize + sizeof(PICPFooter)];
+
+    if (m_pucBuffer)
+    {
+        // Fill the header
+        PICPHeader *pHeader = reinterpret_cast<PICPHeader *>(m_pucBuffer);
+        pHeader->id = 0;
+        pHeader->type = static_cast<uint8_t>(eType);
+        pHeader->command = htonl(eCmd);
+        pHeader->datalength = 0;
+
+        m_bIsValid = true;
+        m_ulCurIndex = sizeof(PICPHeader);
+    }
+}
+
+/****************************************************************************
+     Function: PICP
+     Engineer: Vimalraj Rajasekharan
+        Input: pBuffer - Pointer to input buffer containing message
+               ulSize - Maximum packet size
+       Output: None
+       Return: None
+  Description: Constructor
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+PICP::PICP(uint8_t *pBuffer, uint32_t ulSize)
+    : m_bIsValid(false)
+    , m_bIsCreated(false)
+    , m_pucBuffer(NULL)
+    , m_ulCurIndex(0)
+    , m_eType(PICP_TYPE_INVALID)
+    , m_eCommand(PICP_CMD_INVALID)
+    , m_ulMaxDataSize(0)
+    , m_ulCRC(0)
+{
+    m_pucBuffer = pBuffer;
+    if (m_pucBuffer && ((sizeof(PICPHeader) + sizeof(PICPFooter)) <= ulSize))
+    {
+        PICPHeader *ptrHeader = (PICPHeader*)m_pucBuffer;
+        m_eType = (PICPType)ptrHeader->type;
+        m_eCommand = ntohl(ptrHeader->command);
+        m_ulMaxDataSize = ntohl(ptrHeader->datalength);
+        // Validate header, data length and CRC
+        if ((m_ulMaxDataSize + sizeof(PICPHeader) + sizeof(PICPFooter)) <= ulSize)
+        {
+            m_ulCRC = ntohl(((PICPFooter *) (pBuffer + ulSize - sizeof(PICPFooter)))->crc);
+            if (m_ulCRC == 0xDEADC0DE)
+            {
+                m_bIsValid = true;
+                m_ulCurIndex = sizeof(PICPHeader);
+            }
+        }
+    }
+}
+
+/****************************************************************************
+     Function: ~PICP
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: None
+       Return: None
+  Description: Destructor
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+PICP::~PICP()
+{
+    if (m_pucBuffer && m_bIsCreated)
+    {
+        delete[] m_pucBuffer;
+    }
+}
+
+/****************************************************************************
+     Function: Validate
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: None
+       Return: True if success, false otherwise
+  Description: Validate the packet formatting
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+bool PICP::Validate()
+{
+    return m_bIsValid;
+}
+
+/****************************************************************************
+     Function: AttachData
+     Engineer: Vimalraj Rajasekharan
+        Input: pBuffer - Probe Serial number
+               ulSize - Probe type
+       Output: None
+       Return: True if success, false otherwise
+  Description: Append input data to the message packet
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+bool PICP::AttachData(const uint8_t *pBuffer, uint32_t ulSize)
+{
+    // Add data to the buffer and increment index and data size
+    if (pBuffer == NULL)
+        return false;
+
+    if (ulSize > (m_ulMaxDataSize - (m_ulCurIndex - sizeof(PICPHeader))))
+        return false;
+
+    if (!m_bIsCreated)
+        return false;
+
+    memcpy(&m_pucBuffer[m_ulCurIndex], pBuffer, ulSize);
+    m_ulCurIndex += ulSize;
+
+    return true;
+}
+
+/****************************************************************************
+     Function: SetType
+     Engineer: Vimalraj Rajasekharan
+        Input: eType - Message type
+       Output: None
+       Return: True if success, false otherwise
+  Description: Set packet type
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+bool PICP::SetType(PICPType eType)
+{
+    if (!m_bIsValid)
+        return false;
+
+    PICPHeader *pHeader = reinterpret_cast<PICPHeader *>(m_pucBuffer);
+    pHeader->type = static_cast<uint8_t>(eType);
+
+    return true;
+}
+
+/****************************************************************************
+     Function: SetResponse
+     Engineer: Vimalraj Rajasekharan
+        Input: ulResponse - Response to be set
+       Output: None
+       Return: True if success, false otherwise
+  Description: Set packet return value
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+bool PICP::SetResponse(uint32_t ulResponse)
+{
+    if (!m_bIsValid)
+        return false;
+
+    PICPHeader *pHeader = reinterpret_cast<PICPHeader *>(m_pucBuffer);
+    pHeader->command = htonl(ulResponse);
+
+    return true;
+}
+
+/****************************************************************************
+     Function: SetDataSize
+     Engineer: Vimalraj Rajasekharan
+        Input: ulSize - Data size to be set
+       Output: None
+       Return: True if success, false otherwise
+  Description: Set total data size the packet contains
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+bool PICP::SetDataSize(uint32_t ulSize)
+{
+    if ((m_ulCurIndex + ulSize) <= (sizeof(PICPHeader) + m_ulMaxDataSize))
+    {
+        m_ulCurIndex += ulSize;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+/****************************************************************************
+     Function: GetNextData
+     Engineer: Vimalraj Rajasekharan
+        Input: ulSize - Size of data to be read
+       Output: pBuffer - Pointer to buffer to store data
+       Return: True if success, false otherwise
+  Description: Get next data from current packet
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+bool PICP::GetNextData(uint8_t *pBuffer, uint32_t ulSize)
+{
+    // Read from buffer and return pointer according to index
+    if (pBuffer == NULL)
+        return false;
+
+    if (ulSize && (ulSize > (m_ulMaxDataSize - (m_ulCurIndex - sizeof(PICPHeader)))))
+        return false;
+
+    if (!m_bIsValid || m_bIsCreated)
+        return false;
+
+    memcpy(pBuffer, &m_pucBuffer[m_ulCurIndex], ulSize);
+    m_ulCurIndex += ulSize;
+
+    return true;
+}
+
+/****************************************************************************
+     Function: GetNextData
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: ulSize - Pointer to store size of next data
+       Return: Pointer to next data
+  Description: Get address of next data from current packet
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+uint8_t *PICP::GetNextDataAddress(uint32_t *ulSize)
+{
+    if (!m_bIsValid)
+        return NULL;
+
+    // Read from buffer and return pointer according to index
+    if (ulSize == NULL)
+    {
+        // Return the start address of data
+        return &m_pucBuffer[sizeof(PICPHeader)];
+    }
+    else
+    {
+        *ulSize = m_ulMaxDataSize - (m_ulCurIndex - sizeof(PICPHeader));
+        return &m_pucBuffer[m_ulCurIndex];
+    }
+}
+
+/****************************************************************************
+     Function: GetNextData
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: ulSize - Pointer to store size of packet
+       Return: Pointer to next data
+  Description: Get address of current packet
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+uint8_t *PICP::GetPacketToSend(uint32_t *ulSize)
+{
+    if (!m_bIsCreated)
+        return m_pucBuffer;
+
+    // Fill the header
+    PICPHeader *pHeader = reinterpret_cast<PICPHeader *>(m_pucBuffer);
+    pHeader->datalength = htonl(m_ulCurIndex - sizeof(PICPHeader));
+
+    // Attach CRC (hardcoded now)
+    *reinterpret_cast<uint32_t *>(&m_pucBuffer[m_ulCurIndex]) = htonl(m_ulCRC);
+
+    if (ulSize != NULL)
+    {
+        *ulSize = m_ulCurIndex + sizeof(m_ulCRC);
+    }
+
+    return m_pucBuffer;
+}

--- a/src/SocketIntf.cpp
+++ b/src/SocketIntf.cpp
@@ -1,0 +1,301 @@
+/******************************************************************************
+       Module: SocketIntf.cpp
+     Engineer: Vimalraj Rajasekharan
+  Description: Class for Probe server interface to be used by clients
+  Date           Initials    Description
+  01-Dec-2023    VR          Initial
+******************************************************************************/
+#include <stdio.h>
+#include <errno.h>
+#include "SocketIntf.h"
+#include "PacketFormat.h"
+#ifdef __LINUX
+#include "linuxutils.h"
+#endif
+
+/****************************************************************************
+     Function: SocketIntf
+     Engineer: Vimalraj Rajasekharan
+        Input: usPort - Port number of Probe Server
+       Output: None
+       Return: None
+  Description: Constructor
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+SocketIntf::SocketIntf(uint16_t usPort)
+    : m_socket(INVALID_SOCKET)
+    , m_usPort(usPort)
+{
+#ifndef __LINUX
+    static WSADATA wsaData;
+    int err;
+
+    // Initialize Winsock
+    if ((err = WSAStartup(MAKEWORD(1, 1), &wsaData)) != 0)
+    {
+        printf("WSAStartup failed with error: %d\n", err);
+        return;
+    }
+#endif
+}
+
+/****************************************************************************
+     Function: ~SocketIntf
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: None
+       Return: None
+  Description: Destructor
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+SocketIntf::~SocketIntf()
+{
+    if (m_socket != INVALID_SOCKET)
+    {
+        closesocket(m_socket);
+    }
+#ifndef __LINUX
+    WSACleanup();
+#endif
+}
+
+/****************************************************************************
+     Function: open
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: None
+       Return: Error value
+  Description: Open Socket Client Interface
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+int32_t SocketIntf::open()
+{
+    sockaddr_in serv_addr;
+    int err = 0;
+
+    if (m_socket != INVALID_SOCKET)
+    {
+        // Already opened
+        return err;
+    }
+
+    if ((m_socket = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+    {
+        printf("\n Socket creation error \n");
+        return -1;
+    }
+
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    serv_addr.sin_port = htons(m_usPort);
+
+    if ((err = connect(m_socket, (struct sockaddr *) &serv_addr, sizeof(serv_addr))) < 0)
+    {
+        printf("\nConnection Failed \n");
+#ifndef __LINUX
+        if (h_errno == WSAHOST_NOT_FOUND)
+        {
+            err = ERROR_PROBE_INTF_SERVER_UNREACHABLE;
+        }
+#else
+        if ((errno == EHOSTUNREACH) || (errno == EHOSTDOWN) || (errno == ETIMEDOUT))
+        {
+            err = ERROR_PROBE_INTF_SERVER_UNREACHABLE;
+        }
+#endif
+    }
+
+    return err;
+}
+
+/****************************************************************************
+     Function: close
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: None
+       Return: Error value
+  Description: Close Socket Client Interface
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+int32_t SocketIntf::close()
+{
+    int32_t ret = -1;
+
+    if (m_socket != INVALID_SOCKET)
+    {
+        ret = closesocket(m_socket);
+        m_socket = INVALID_SOCKET;
+    }
+
+    return ret;
+}
+
+/****************************************************************************
+     Function: write
+     Engineer: Vimalraj Rajasekharan
+        Input: data - Pointer to buffer containing data
+               size - Size of data to be written
+       Output: None
+       Return: Total bytes written
+  Description: Write data to Socket Client Interface
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+int32_t SocketIntf::write(uint8_t *data, uint32_t size)
+{
+    if (m_socket == INVALID_SOCKET)
+        return -1;
+
+    if (data == NULL)
+        return -1;
+
+    // Send to Server
+    // TODO: Check error and completion of transfer of full data
+    int writtenBytes = 0;
+    uint32_t totalBytes = 0;
+
+    while (totalBytes < size)
+    {
+        writtenBytes = send(m_socket, (const char *) (data + totalBytes), (size - totalBytes), 0);
+        if (writtenBytes < 0)
+        {
+            totalBytes = writtenBytes;
+            break;
+        }
+        else
+        {
+            totalBytes += writtenBytes;
+        }
+    }
+
+    return totalBytes;
+}
+
+/****************************************************************************
+     Function: read
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: data - Pointer to buffer to store data
+               size - Size of data read
+       Return: Total bytes read
+  Description: Read data from Socket Client Interface
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+int32_t SocketIntf::read(uint8_t *data, uint32_t *size)
+{
+    if (m_socket == INVALID_SOCKET)
+        return -1;
+
+    if (data == NULL)
+        return -1;
+
+    // Recieve from client
+    // TODO: Check error and completion of transfer of full data
+    int readBytes = 0;
+    int totalBytes = 0;
+    int remainingBytes = sizeof(PICPHeader);
+    if (remainingBytes > (int) *size)
+    {
+        return -1;
+    }
+
+    readBytes = recv(m_socket, (char *) data, remainingBytes, 0);
+    if (readBytes < 0)
+    {
+        // This is not expected, return error
+        totalBytes = -1;
+    }
+    else if (readBytes == sizeof(PICPHeader))
+    {
+        remainingBytes = sizeof(PICPHeader) + ntohl(((PICPHeader *) data)->datalength) + sizeof(PICPFooter);
+        if (remainingBytes > (int)*size)
+        {
+            return -1;
+        }
+        remainingBytes -= readBytes;
+
+        totalBytes = readBytes;
+        while (remainingBytes > 0)
+        {
+            readBytes = recv(m_socket, (char *) (data + totalBytes), remainingBytes, 0);
+            if (readBytes <= 0)
+            {
+                // Read error
+                totalBytes = -1;
+                break;
+            }
+            remainingBytes -= readBytes;
+            totalBytes += readBytes;
+        }
+        *size = totalBytes;
+    }
+    else
+    {
+        // This is not expected, return error
+        totalBytes = -1;
+    }
+
+    return totalBytes;
+}
+
+/****************************************************************************
+     Function: readtrace
+     Engineer: Vimalraj Rajasekharan
+        Input: None
+       Output: data - Pointer to buffer to store data
+               size - Size of data read
+       Return: Total bytes read
+  Description: Read trace data from Socket Client Interface
+Date           Initials    Description
+31-Oct-2023    VR          Initial
+****************************************************************************/
+uint32_t SocketIntf::readtrace(uint8_t *data, uint32_t *size)
+{
+    if (m_socket == INVALID_SOCKET)
+        return (uint32_t)(-1);
+
+    if (data == NULL)
+        return (uint32_t)(-1);
+
+    // Recieve from client
+    // TODO: Check error and completion of transfer of full data
+    bool bIsResponse = true;
+    int readBytes = 0;
+    int totalBytes = 0;
+    int remainingBytes = *size;
+
+    while (remainingBytes > 0)
+    {
+        readBytes = recv(m_socket, (char *) (data + totalBytes), remainingBytes, 0);
+        if (bIsResponse)
+        {
+            PICP retPacket(data, sizeof(PICPHeader) + sizeof(PICPFooter));
+            if (retPacket.Validate())
+            {
+                if (retPacket.GetResponse() != 0)
+                {
+                    // Read error
+                    totalBytes = -1;
+                    break;
+                }
+            }
+            bIsResponse = false;
+        }
+        if (readBytes <= 0)
+        {
+            // Read error
+            totalBytes = -1;
+            break;
+        }
+        remainingBytes -= readBytes;
+        totalBytes += readBytes;
+    }
+    *size = totalBytes;
+
+    return totalBytes;
+}

--- a/src/dqr_profiler.cpp
+++ b/src/dqr_profiler.cpp
@@ -1,0 +1,13179 @@
+/* Copyright 2022 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cstring>
+#include <cstdint>
+#include "unistd_profiler.h"
+//#include <unistd.h>
+#include <fcntl.h>
+#ifdef WINDOWS
+#include <winsock2.h>
+#include <namedpipeapi.h>
+#else // WINDOWS
+//#include <netdb.h>
+//#include <sys/ioctl.h>
+#include <errno.h>
+#include <sys/types.h>
+ #include <sys/wait.h>
+//#include <sys/wait.h>
+#endif // WINDOWS
+
+#include "dqr_profiler.h"
+#include "dqr_trace_profiler.h"
+
+//#define DQR_PROFILER_MAXCORES	8
+
+int profiler_globalDebugFlag = 0;
+
+// DECODER_VERSION is passed in from the Makefile, from version.mk in the root.
+const char* const DQR_PROFILER_VERSION = "DECODER_VERSION";
+
+// static C type helper functions
+
+static int atoh(char a)
+{
+	if (a >= '0' && a <= '9') {
+		return a - '0';
+	}
+
+	if (a >= 'a' && a <= 'f') {
+		return a - 'a' + 10;
+	}
+
+	if (a >= 'A' && a <= 'F') {
+		return a - 'A' + 10;
+	}
+
+	return -1;
+}
+
+// Section Class Methods
+cachedInstInfo::cachedInstInfo(const char* file, int cutPathIndex, const char* func, int linenum, const char* lineTxt, const char* instText, TraceDqrProfiler::RV_INST inst, int instSize, const char* addresslabel, int addresslabeloffset)
+{
+	// Don't need to allocate and copy file and function. They will remain until trace object is deleted
+
+	filename = file;
+	this->cutPathIndex = cutPathIndex;
+	functionname = func;
+	linenumber = linenum;
+	lineptr = lineTxt;
+
+	instruction = inst;
+	instsize = instSize;
+
+	addressLabel = addresslabel;
+	addressLabelOffset = addresslabeloffset;
+
+	// Need to allocate and copy instruction. src changes every time an instruction is disassembled, so we need to save it
+
+	if (instText != nullptr) {
+		int	s = strlen(instText) + 1;
+		instructionText = new char[s];
+		strcpy(instructionText, instText);
+	}
+	else {
+		instructionText = nullptr;
+	}
+}
+
+cachedInstInfo::~cachedInstInfo()
+{
+	filename = nullptr;
+	functionname = nullptr;
+	lineptr = nullptr;
+	addressLabel = nullptr;
+
+	if (instructionText != nullptr) {
+		delete[] instructionText;
+		instructionText = nullptr;
+	}
+}
+
+void cachedInstInfo::dump()
+{
+	printf("cachedInstInfo()\n");
+	printf("filename: '%s'\n", filename);
+	printf("fucntion: '%s'\n", functionname);
+	printf("linenumber: %d\n", linenumber);
+	printf("lineptr: '%s'\n", lineptr);
+	printf("instructin: 0x%08x\n", instruction);
+	printf("instruction size: %d\n", instsize);
+	printf("instruction text: '%s'\n", instructionText);
+	printf("addressLabel: '%s'\n", addressLabel);
+	printf("addressLabelOffset: %d\n", addressLabelOffset);
+}
+
+// work with elf file sections
+
+Section::Section()
+{
+	next = nullptr;
+	name[0] = 0;
+	flags = 0;
+	size = 0;
+	offset = 0;
+	startAddr = (TraceDqrProfiler::ADDRESS)0;
+	endAddr = (TraceDqrProfiler::ADDRESS)0;
+	code = nullptr;
+	fName = nullptr;
+	line = nullptr;
+	diss = nullptr;
+	cachedInfo = nullptr;
+}
+
+Section::~Section()
+{
+	if (code != nullptr) {
+		delete[] code;
+		code = nullptr;
+	}
+
+	if (fName != nullptr) {
+		// what fNameo[] points to will be deleted when deleting srcFileRoot object
+		delete[] fName;
+		fName = nullptr;
+	}
+
+	if (line != nullptr) {
+		delete[] line;
+		line = nullptr;
+	}
+
+	if (diss != nullptr) {
+		for (unsigned int i = 0; i < size / 2; i++) {
+			if (diss[i] != nullptr) {
+				delete[] diss[i];
+				diss[i] = nullptr;
+			}
+		}
+		delete[] diss;
+		diss = nullptr;
+	}
+
+	if (cachedInfo != nullptr) {
+		for (unsigned int i = 0; i < size / 2; i++) {
+			if (cachedInfo[i] != nullptr) {
+				delete cachedInfo[i];
+				cachedInfo[i] = nullptr;
+			}
+		}
+
+		delete[] cachedInfo;
+		cachedInfo = nullptr;
+	}
+}
+
+void Section::dump()
+{
+	printf("section: %s 0x%08x - 0x%08x, size: %u, flags: 0x%08x\n", name, startAddr, endAddr, size, flags);
+
+	if ((flags & Section::sect_CODE) && (fName != nullptr) && (line != nullptr)) {
+		for (uint32_t i = 0; i < size / 2; i++) {
+			printf("[%u]: addr: 0x%08llx, %s:%d\n", i, startAddr + i * 2, fName[i], line[i]);
+		}
+	}
+}
+
+Section* Section::getSectionByAddress(TraceDqrProfiler::ADDRESS addr)
+{
+	Section* sp = this;
+
+	while (sp != nullptr) {
+		if ((addr >= sp->startAddr) && (addr <= sp->endAddr)) {
+			return sp;
+		}
+
+		sp = sp->next;
+	}
+
+	return nullptr;
+}
+
+Section* Section::getSectionByName(char* secName)
+{
+	Section* sp = this;
+
+	while (sp != nullptr) {
+		if (strcmp(sp->name,secName) == 0) {
+			return sp;
+		}
+
+		sp = sp->next;
+	}
+
+	return nullptr;
+}
+
+cachedInstInfo* Section::setCachedInfo(TraceDqrProfiler::ADDRESS addr, const char* file, int cutPathIndex, const char* func, int linenum, const char* lineTxt, const char* instTxt, TraceDqrProfiler::RV_INST inst, int instSize, const char* addresslabel, int addresslabeloffset)
+{
+	if ((addr >= startAddr) && (addr <= endAddr)) {
+		if (cachedInfo != nullptr) {
+
+			int index = (addr - startAddr) >> 1;
+
+			if (cachedInfo[index] != nullptr) {
+				printf("Error: Section::setCachedInfo(): cachedInfo[%d] not null\n", index);
+				return nullptr;
+			}
+
+			cachedInstInfo* cci;
+			cci = new cachedInstInfo(file, cutPathIndex, func, linenum, lineTxt, instTxt, inst, instSize, addresslabel, addresslabeloffset);
+
+			cachedInfo[index] = cci;
+
+			return cci;
+		}
+	}
+
+	return nullptr;
+}
+
+cachedInstInfo* Section::getCachedInfo(TraceDqrProfiler::ADDRESS addr)
+{
+	if ((addr >= startAddr) && (addr <= endAddr)) {
+		if (cachedInfo != nullptr) {
+			return cachedInfo[(addr - startAddr) >> 1];
+		}
+	}
+
+	return nullptr;
+}
+
+int        ProfilerInstruction::addrSize;
+uint32_t   ProfilerInstruction::addrDispFlags;
+int        ProfilerInstruction::addrPrintWidth;
+
+std::string ProfilerInstruction::addressToString(int labelLevel)
+{
+	char dst[128];
+
+	addressToText(dst, sizeof dst, labelLevel);
+
+	return std::string(dst);
+}
+
+void ProfilerInstruction::addressToText(char* dst, size_t len, int labelLevel)
+{
+	if (dst == nullptr) {
+		printf("Error: ProfilerInstruction::addressToText(): Argument dst is null\n");
+		return;
+	}
+
+	dst[0] = 0;
+
+	if (addrDispFlags & TraceDqrProfiler::ADDRDISP_WIDTHAUTO) {
+		while (address > (0xffffffffffffffffllu >> (64 - addrPrintWidth * 4))) {
+			addrPrintWidth += 1;
+		}
+	}
+
+	int n;
+
+	if ((addrPrintWidth > 8) && (addrDispFlags & TraceDqrProfiler::ADDRDISP_SEP)) {
+		n = snprintf(dst, len, "%0*x.%08x", addrPrintWidth - 8, (uint32_t)(address >> 32), (uint32_t)address);
+	}
+	else {
+		n = snprintf(dst, len, "%0*llx", addrPrintWidth, address);
+	}
+
+	if ((labelLevel >= 1) && (addressLabel != nullptr)) {
+		if (addressLabelOffset != 0) {
+			snprintf(dst + n, len - n, " <%s+%x>", addressLabel, addressLabelOffset);
+		}
+		else {
+			snprintf(dst + n, len - n, " <%s>", addressLabel);
+		}
+	}
+}
+
+std::string ProfilerInstruction::instructionToString(int labelLevel)
+{
+	char dst[128];
+
+	instructionToText(dst, sizeof dst, labelLevel);
+
+	return std::string(dst);
+}
+
+void ProfilerInstruction::instructionToText(char* dst, size_t len, int labelLevel)
+{
+	if (dst == nullptr) {
+		printf("Error: ProfilerInstruction::instructionToText(): Argument dst is null\n");
+		return;
+	}
+
+	dst[0] = 0;
+
+	//	should cache this (as part of other instruction stuff cached)!!
+
+	if (instSize == 32) {
+		snprintf(dst, len, "%08x    %s", instruction, instructionText);
+	}
+	else {
+		snprintf(dst, len, "%04x        %s", instruction, instructionText);
+	}
+}
+
+std::string ProfilerInstruction::addressLabelToString()
+{
+
+	if (addressLabel != nullptr) {
+		return std::string(addressLabel);
+	}
+
+	return std::string("");
+}
+
+const char* ProfilerSource::stripPath(const char* path)
+{
+	if (path == nullptr) {
+		return sourceFile;
+	}
+
+	const char* s = sourceFile;
+
+	if (s == nullptr) {
+		return nullptr;
+	}
+
+	for (;;) {
+		if (*path == 0) {
+			return s;
+		}
+
+		if (tolower(*path) == tolower(*s)) {
+			path += 1;
+			s += 1;
+		}
+		else if (*path == '/') {
+			if (*s != '\\') {
+				return sourceFile;
+			}
+			path += 1;
+			s += 1;
+		}
+		else if (*path == '\\') {
+			if (*s != '/') {
+				return sourceFile;
+			}
+			path += 1;
+			s += 1;
+		}
+		else {
+			return sourceFile;
+		}
+	}
+
+	return nullptr;
+}
+
+std::string ProfilerSource::sourceFileToString(std::string path)
+{
+	if (sourceFile != nullptr) {
+		// check for garbage in path/file name
+
+		const char* sf = stripPath(path.c_str());
+		if (sf == nullptr) {
+			printf("Error: sourceFileToString(): stripPath() returned nullptr\n");
+		}
+		else {
+			for (int i = 0; sf[i] != 0; i++) {
+				switch (sf[i]) {
+				case 'a':
+				case 'b':
+				case 'c':
+				case 'd':
+				case 'e':
+				case 'f':
+				case 'g':
+				case 'h':
+				case 'i':
+				case 'j':
+				case 'k':
+				case 'l':
+				case 'm':
+				case 'n':
+				case 'o':
+				case 'p':
+				case 'q':
+				case 'r':
+				case 's':
+				case 't':
+				case 'u':
+				case 'v':
+				case 'w':
+				case 'x':
+				case 'y':
+				case 'z':
+				case 'A':
+				case 'B':
+				case 'C':
+				case 'D':
+				case 'E':
+				case 'F':
+				case 'G':
+				case 'H':
+				case 'I':
+				case 'J':
+				case 'K':
+				case 'L':
+				case 'M':
+				case 'N':
+				case 'O':
+				case 'P':
+				case 'Q':
+				case 'R':
+				case 'S':
+				case 'T':
+				case 'U':
+				case 'V':
+				case 'W':
+				case 'X':
+				case 'Y':
+				case 'Z':
+				case '0':
+				case '1':
+				case '2':
+				case '3':
+				case '4':
+				case '5':
+				case '6':
+				case '7':
+				case '8':
+				case '9':
+				case '/':
+				case '\\':
+				case '.':
+				case '_':
+				case '-':
+				case '+':
+				case ':':
+					break;
+				default:
+					printf("Error: source::srouceFileToSTring(): File name '%s' contains bogus char (0x%02x) in position %d!\n", sf, sf[i], i);
+					break;
+				}
+			}
+		}
+	}
+
+	if (sourceFile != nullptr) {
+
+		const char* sf = stripPath(path.c_str());
+
+		return std::string(sf);
+	}
+
+	return std::string("");
+}
+
+std::string ProfilerSource::sourceFileToString()
+{
+	if (sourceFile != nullptr) {
+		return std::string(sourceFile);
+	}
+
+	return std::string("");
+}
+
+std::string ProfilerSource::sourceLineToString()
+{
+	if (sourceLine != nullptr) {
+		return std::string(sourceLine);
+	}
+
+	return std::string("");
+}
+
+std::string ProfilerSource::sourceFunctionToString()
+{
+	if (sourceFunction != nullptr) {
+		return std::string(sourceFunction);
+	}
+
+	return std::string("");
+}
+
+fileReader::fileReader(/*paths*/)
+{
+	lastFile = nullptr;
+	files = nullptr;
+	cutPath = nullptr;
+	newRoot = nullptr;
+}
+
+fileReader::~fileReader()
+{
+	if (cutPath != nullptr) {
+		delete[] cutPath;
+		cutPath = nullptr;
+	}
+
+	if (newRoot != nullptr) {
+		delete[] newRoot;
+		newRoot = nullptr;
+	}
+
+	for (fileList* fl = files; fl != nullptr;) {
+		fileList* nextFl = fl->next;
+
+		for (funcList* func = fl->funcs; func != nullptr;) {
+			funcList* nextFunc = func->next;
+			if (func->func != nullptr) {
+				delete[] func->func;
+				func->func = nullptr;
+			}
+			delete func;
+			func = nextFunc;
+		}
+
+		if (fl->name != nullptr) {
+			delete[] fl->name;
+			fl->name = nullptr;
+		}
+
+		if (fl->lines != nullptr) {
+			if (fl->lines[0] != nullptr) {
+				delete[] fl->lines[0];
+			}
+			delete fl->lines;
+			fl->lines = nullptr;
+		}
+
+		fl = nextFl;
+	}
+
+	files = nullptr;
+}
+
+fileReader::fileList* fileReader::readFile(const char* file)
+{
+	if (file == nullptr) {
+		printf("Error: fileReader::readFile(): No file specified\n");
+		return nullptr;
+	}
+
+	std::ifstream  f;
+	const char* original_file_name = file;
+	int fi = 0; // file name inmdex
+
+	if ((cutPath != nullptr) && (cutPath[0] != 0)) {
+		// the plan is to strip off the cutpath portion of the file name and try to open the file
+		// if that doesn't work, try the original file name
+		// if that doesn't work, try just the file name with no path info
+
+		char cpDrive = 0;
+		char fnDrive = 0;
+		int ci = 0; // cut path index
+
+		// the tricky part is if this is windows and there is a drive designator, handle that
+		// the cut path may or may not have a drive designator.
+		// Unix-like OSs don't mess with such silly stuff
+
+		// check for a drive designator on the cut path string
+
+		if ((cutPath[0] != 0) && (cutPath[1] == ':')) {
+			if ((cutPath[0] >= 'a') && (cutPath[0] <= 'z')) {
+				cpDrive = 'A' + (cutPath[0] - 'a');
+				ci = 2;
+			}
+			else if ((cutPath[0] >= 'A') && (cutPath[0] <= 'Z')) {
+				cpDrive = cutPath[0];
+				ci = 2;
+			}
+		}
+
+		// check for a drive designator on the file name string
+
+		if ((file[0] != 0) && (file[1] == ':')) {
+			if ((file[0] >= 'a') && (file[0] <= 'z')) {
+				fnDrive = 'A' + (file[0] - 'a');
+				fi = 2;
+			}
+			else if ((file[0] >= 'A') && (file[0] <= 'Z')) {
+				fnDrive = file[0];
+				fi = 2;
+			}
+		}
+
+		// if there are drive designators for both, they must match. If there are no drive
+		// designators, they match. If there is a drive designators for file and none for cutpath
+		// and the drive designtor for file is 'C:', they match.
+
+		bool match = true;
+
+		if (cpDrive == fnDrive) {
+			// have a match. Either neither has a drive, or both have the same drive
+		}
+		else if ((cpDrive == 0) && (fnDrive == 'C')) {
+			// have a match. Default to cpDrive of 'C' if nont specified.
+		}
+		else {
+			// no match
+			match = false;
+		}
+
+		/* \ matches /, / matches \ */
+
+		while (match && (cutPath[ci] != 0) && (file[fi] != 0)) {
+			if (cutPath[ci] == file[fi]) {
+				ci += 1;
+				fi += 1;
+			}
+			else if ((cutPath[ci] == '/') && (file[fi] == '\\')) {
+				ci += 1;
+				fi += 1;
+			}
+			else if ((cutPath[ci] == '\\') && (file[fi] == '/')) {
+				ci += 1;
+				fi += 1;
+			}
+			else {
+				match = false;
+			}
+		}
+
+		if (cutPath[ci] != 0) {
+			match = false;
+		}
+
+		if (match == false) {
+			fi = 0;
+		}
+
+		//		printf("cutPath: %s\n",cutPath);
+		//		printf("file: %s\n",file);
+		//
+		//		if (match) {
+		//			printf("match!\n");
+		//
+		//			printf("remaining path: %s\n",&file[fi]);
+		//		}
+		//		else {
+		//			printf("no match!\n");
+		//		}
+
+		if ((match == true) && (newRoot != nullptr)) {
+			int fl = strlen(&file[fi]);
+			int rl = strlen(newRoot);
+			char* newName;
+			newName = new char[fl + rl + 1];
+
+			strcpy(newName, newRoot);
+			strcpy(&newName[rl], &file[fi]);
+
+			//			printf("newName: %s\n",newName);
+
+			f.open(newName, std::ifstream::binary);
+
+			delete[] newName;
+			newName = nullptr;
+		}
+		else {
+			f.open(&file[fi], std::ifstream::binary);
+		}
+	}
+	else {
+		f.open(file, std::ifstream::binary);
+
+		if (!f) {
+			//		printf("Error: readFile(): could not open file %s for input\n",file);
+
+					// try again after stripping off path
+
+			int l = -1;
+
+			for (int i = 0; file[i] != 0; i++) {
+				if ((file[i] == '/') || (file[i] == '\\')) {
+					l = i;
+				}
+			}
+
+			if (l != -1) {
+				file = &file[l + 1];
+				f.open(file, std::ifstream::binary);
+			}
+		}
+	}
+
+	fileList* fl = new fileList;
+
+	fl->next = files;
+	fl->funcs = nullptr;
+	files = fl;
+
+	int len = strlen(original_file_name) + 1;
+	char* name = new char[len];
+	strcpy(name, original_file_name);
+
+	fl->name = name;
+	fl->cutPathIndex = fi;
+
+	if (!f) {
+		// always return a file list pointer, even if a file isn't found. If file not
+		// found, lines will be null
+
+		fl->lineCount = 0;
+		fl->lines = nullptr;
+
+		return fl;
+	}
+
+	// get length of file:
+
+	f.seekg(0, f.end);
+	int length = f.tellg();
+	f.seekg(0, f.beg);
+
+	// allocate memory:
+
+	char* buffer = new char[length + 1]; // allocate an extra byte in case the file does not end with \n
+
+	// read file into buffer
+
+	f.read(buffer, length);
+
+	f.close();
+
+	// count lines
+
+	int lc = 1;
+
+	for (int i = 0; i < length; i++) {
+		if (buffer[i] == '\n') {
+			lc += 1;
+		}
+		else if (i == length - 1) {
+			// last line does not have a \n
+			lc += 1;
+		}
+	}
+
+	// create array of line pointers
+
+	char** lines = new char* [lc];
+
+	// initialize arry of ptrs
+
+	int l;
+	int s;
+
+	l = 0;
+	s = 1;
+
+	for (int i = 0; i < length; i++) {
+		if (s != 0) {
+			lines[l] = &buffer[i];
+			l += 1;
+			s = 0;
+		}
+
+		// strip out CRs and LFs
+
+		if (buffer[i] == '\r') {
+			buffer[i] = 0;
+		}
+		else if (buffer[i] == '\n') {
+			buffer[i] = 0;
+			s = 1;
+		}
+	}
+
+	buffer[length] = 0;	// make sure last line is nul terminated
+
+	if (l >= lc) {
+		delete[] lines;
+		delete[] buffer;
+
+		fl->lineCount = 0;
+		fl->lines = nullptr;
+
+		printf("Error: readFile(): Error computing line count for file %s, l:%d, lc: %d\n", file, l, lc);
+
+		return nullptr;
+	}
+
+	lines[l] = nullptr;
+
+	fl->lineCount = l;
+	fl->lines = lines;
+
+	return fl;
+}
+
+fileReader::fileList* fileReader::findFile(const char* file)
+{
+	if (file == nullptr) {
+		printf("Error: fileReader::findFile(): No file specified\n");
+		return nullptr;
+	}
+
+	// first check if file is same as last one uesed
+
+	if (lastFile != nullptr) {
+		if (strcmp(lastFile->name,file) == 0) {
+			// found file!
+			return lastFile;
+		}
+	}
+
+	struct fileList* fp;
+
+	for (fp = files; fp != nullptr; fp = fp->next) {
+		if (strcmp(fp->name,file) == 0) {
+			lastFile = fp;
+			return fp;
+		}
+	}
+
+	// didn't find file. See if we can read it in
+
+	fp = readFile(file);
+
+	return fp;
+}
+
+TraceDqrProfiler::DQErr fileReader::subSrcPath(const char* cutPath, const char* newRoot)
+{
+	if (this->cutPath != nullptr) {
+		delete[] this->cutPath;
+		this->cutPath = nullptr;
+	}
+
+	if (this->newRoot != nullptr) {
+		delete[] this->newRoot;
+		this->newRoot = nullptr;
+	}
+
+	if (cutPath != nullptr) {
+		int l = strlen(cutPath) + 1;
+
+		this->cutPath = new char[l];
+
+		strcpy(this->cutPath, cutPath);
+	}
+
+	if (newRoot != nullptr) {
+		int l = strlen(newRoot) + 1;
+
+		this->newRoot = new char[l];
+
+		strcpy(this->newRoot, newRoot);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+static int symCompareFunc(const void* arg1, const void* arg2)
+{
+	if (arg1 == nullptr) {
+		printf("Error: symCompareFunc(): Null first argument\n");
+		return 0;
+	}
+
+	if (arg2 == nullptr) {
+		printf("Error: symCompareFunc(): Null second argument\n");
+		return 0;
+	}
+
+	Sym* first;
+	Sym* second;
+
+	first = *(Sym**)arg1;
+	second = *(Sym**)arg2;
+
+	int64_t cv;
+	cv = first->address - second->address;
+
+	int rv;
+
+	// > 0: first comes after second, return 1
+	// < 0: first comes before second, return -1
+	// = 0: break tie:
+	// 	if first is weak and second is not, first comes after second, return 1
+	// 	if first is not weak and second is weak, first comes before second, return -1
+	//
+	// 	if first is debug and second is not, first comes after second, return 1
+	// 	if first is not debug and second is debug, first comes before second, return -1
+	//
+	// 	if first is not global and second is global, first comes after second, return 1
+	// 	if first is global and seoncd is not global, first comes before second, return -1
+	//
+	//	if first is not a function and second is a function, first comes after second, return 1
+	//	if first is a function and second is not a function, first comes before second, return -1
+	//
+	// 	otherwise, return 0
+
+	if (cv > 0) {
+		rv = 1;
+	}
+	else if (cv < 0) {
+		rv = -1;
+	}
+	else {
+		// if addrs are same, use weak as the tie breaker, or global, or debug
+
+		if ((first->flags & Sym::symWeak) && !(second->flags & Sym::symWeak)) {
+			rv = 1;
+		}
+		else if (!(first->flags & Sym::symWeak) && (second->flags & Sym::symWeak)) {
+			rv = -1;
+		}
+		else if ((first->flags & Sym::symDebug) && !(second->flags & Sym::symDebug)) {
+			rv = 1;
+		}
+		else if (!(first->flags & Sym::symDebug) && (second->flags & Sym::symDebug)) {
+			rv = -1;
+		}
+		else if (!(first->flags & Sym::symGlobal) && (second->flags & Sym::symGlobal)) {
+			rv = 1;
+		}
+		else if ((first->flags & Sym::symGlobal) && !(second->flags & Sym::symGlobal)) {
+			rv = -1;
+		}
+		else if (!(first->flags & Sym::symFunc) && (second->flags & Sym::symFunc)) {
+			rv = 1;
+		}
+		else if ((first->flags & Sym::symFunc) && !(second->flags & Sym::symFunc)) {
+			rv = -1;
+		}
+		else {
+			// If we get here, the address and attributes are the same. So we do a
+			// compare of the names, just to make this deterministic across platforms
+
+       		rv = strcmp(first->name,second->name);
+		}
+	}
+
+	return rv;
+}
+
+Symtab::Symtab(Sym* syms)
+{
+	status = TraceDqrProfiler::DQERR_OK;
+
+	numSyms = 0;
+
+	if (syms == nullptr) {
+		printf("Info: No symbol information\n");
+
+		symLst = nullptr;
+		numSyms = 0;
+
+		return;
+	}
+
+	cachedSymAddr = 0;
+	cachedSymSize = 0;
+	cachedSymIndex = -1;
+
+	symLst = syms;
+
+	Sym* symPtr;
+
+	for (symPtr = syms; symPtr != nullptr; symPtr = symPtr->next) {
+		numSyms += 1;
+	}
+
+	symPtrArray = new struct Sym* [numSyms];
+
+	symPtr = syms;
+
+	//        	make sure all symbols with no type info in code sections have function type added!
+
+	for (int i = 0; i < numSyms; i++) {
+		symPtrArray[i] = symPtr;
+
+		symPtr = symPtr->next;
+	}
+
+	// note: qsort does not preserver order on equal items!
+
+	qsort((void*)symPtrArray, (size_t)numSyms, sizeof symPtrArray[0], symCompareFunc);
+
+	TraceDqrProfiler::DQErr rc;
+
+	rc = fixupFunctionSizes();
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+	}
+}
+
+Symtab::~Symtab()
+{
+	if (symLst != nullptr) {
+		Sym* nextSym;
+		nextSym = symLst;
+		while (nextSym != nullptr) {
+			Sym* tmpSymPtr;
+			tmpSymPtr = nextSym->next;
+
+			nextSym->srcFile = nullptr;
+
+			if (nextSym->name != nullptr) {
+				delete[] nextSym->name;
+				nextSym->name = nullptr;
+			}
+
+			delete nextSym;
+			nextSym = tmpSymPtr;
+		}
+
+		symLst = nullptr;
+	}
+
+	if (symPtrArray != nullptr) {
+		delete[] symPtrArray;
+		symPtrArray = nullptr;
+	}
+}
+
+TraceDqrProfiler::DQErr Symtab::fixupFunctionSizes()
+{
+	bool haveStartSym;
+
+	for (int s = 0; s < numSyms; s++) {
+		haveStartSym = false;
+
+		if (symPtrArray[s]->size == 0) {
+			// compute size as distance to next symbol
+
+			// if no section, don't have a start sym!
+			// if debug, don't have a start sym!
+
+			if (!(symPtrArray[s]->flags & Sym::symDebug) && (symPtrArray[s]->section != nullptr)) {
+				haveStartSym = true;
+			}
+		}
+
+		if (haveStartSym) {
+			// look for following symbol - does not need to have a size of 0
+
+			bool haveEndSym;
+			haveEndSym = false;
+
+			for (int e = s + 1; (e < numSyms) && !haveEndSym; e++) {
+				if (symPtrArray[s]->section != symPtrArray[e]->section) {
+					// went past end of section
+					// size is from sym to end of section
+
+					symPtrArray[s]->size = symPtrArray[s]->section->endAddr + 1 - symPtrArray[s]->address;
+
+					haveEndSym = true;
+				}
+				else if (symPtrArray[e]->address != symPtrArray[s]->address) {
+					if (!(symPtrArray[s]->flags & Sym::symDebug)) {
+						symPtrArray[s]->size = symPtrArray[e]->address - symPtrArray[s]->address;
+
+						haveEndSym = true;
+					}
+				}
+			}
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Symtab::lookupSymbolByAddress(TraceDqrProfiler::ADDRESS addr, Sym*& sym)
+{
+	if (addr == 0) {
+		sym = nullptr;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// check for a cache hit
+
+	if ((addr >= cachedSymAddr) && (addr < (cachedSymAddr + cachedSymSize))) {
+		sym = symPtrArray[cachedSymIndex];
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	// not in cache, go look for it
+
+	// maybe use a binary search in the future - maybe not. bsearch will not always get the first
+
+	int found = -1;
+
+	for (int i = 0; (found == -1) && (i < numSyms); i++) {
+		if ((addr >= symPtrArray[i]->address) && (addr < (symPtrArray[i]->address + symPtrArray[i]->size))) {
+			found = i;
+		}
+	}
+
+	if (found >= 0) {
+		// found - cache it
+
+		cachedSymIndex = found;
+		cachedSymAddr = symPtrArray[found]->address;
+
+		sym = symPtrArray[found];
+	}
+	else {
+		sym = nullptr;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+void Symtab::dump()
+{
+	printf("number_of_symbols: %ld\n", numSyms);
+
+	for (int i = 0; i < numSyms; i++) {
+		printf("sym[%d]: address: 0x%08llx, size: %8u ",
+			i,
+			symPtrArray[i]->address,
+			(uint32_t)symPtrArray[i]->size);
+
+		uint32_t flags = symPtrArray[i]->flags;
+
+		if ((flags & (Sym::symLocal | Sym::symGlobal)) == (Sym::symLocal | Sym::symGlobal)) {
+			printf("!");
+		}
+		else if (flags & Sym::symLocal) {
+			printf("l");
+		}
+		else if (flags & Sym::symGlobal) {
+			printf("g");
+		}
+		else {
+			printf(" ");
+		}
+
+		if (flags & Sym::symWeak) {
+			printf("w");
+		}
+		else {
+			printf(" ");
+		}
+
+		if (flags & Sym::symConstructor) {
+			printf("C");
+		}
+		else {
+			printf(" ");
+		}
+
+		if (flags & Sym::symIndirect) {
+			printf("I");
+		}
+		else if (flags & Sym::symIndirectFunc) {
+			printf("i");
+		}
+		else {
+			printf(" ");
+		}
+
+		if (flags & Sym::symDebug) {
+			printf("d");
+		}
+		else if (flags & Sym::symDynamic) {
+			printf("D");
+		}
+		else {
+			printf(" ");
+		}
+
+		if (flags & Sym::symFunc) {
+			printf("F");
+		}
+		else if (flags & Sym::symFile) {
+			printf("f");
+		}
+		else if (flags & Sym::symObj) {
+			printf("O");
+		}
+		else {
+			printf(" ");
+		}
+
+		printf(" %s, ", symPtrArray[i]->name);
+
+		if (symPtrArray[i]->section != nullptr) {
+			printf(" section: %s\n", symPtrArray[i]->section->name);
+		}
+		else {
+			printf(" section: no section\n");
+		}
+	}
+}
+
+ObjDump::ObjDump(const char* elfName, const char* objdumpPath, int& archSize, Section*& codeSectionLst, Sym*& syms, SrcFileRoot& srcFileRoot)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	status = TraceDqrProfiler::DQERR_OK;
+
+	stdoutPipe = -1;
+	objdumpPid = (int32_t)-1;
+	fpipe = nullptr;
+
+	pipeEOF = false;
+	pipeIndex = 0;
+	endOfBuffer = 0;
+
+	rc = execObjDump(elfName, objdumpPath);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = TraceDqrProfiler::DQERR_ERR;
+		pipeEOF = true;
+
+		return;
+	}
+
+	rc = parseObjdump(archSize, codeSectionLst, syms, srcFileRoot);
+
+#ifndef WINDOWS
+
+	int status;
+	status = 0;
+
+	waitpid(objdumpPid, &status, 0);
+
+#endif	// WINDOWS
+
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = TraceDqrProfiler::DQERR_ERR;
+	}
+}
+
+ObjDump::~ObjDump()
+{
+	if (stdoutPipe >= 0) {
+		_close(stdoutPipe);
+		stdoutPipe = -1;
+	}
+
+	if (fpipe != nullptr) {
+		fclose(fpipe);
+		fpipe = nullptr;
+	}
+}
+
+#ifdef WINDOWS
+#define PATH_SEP "\\"
+#define PATH_SEG_SEP ';'
+#else // WINDOWS
+#define PATH_SEP "/"
+#define PATH_SEG_SEP ':'
+#endif // WINDOWS
+
+static TraceDqrProfiler::DQErr findObjDump(char* objDump, bool& foundExec)
+{
+	//	printf("findObjDump(): %s\n",objDump);
+
+	foundExec = false;
+
+	if (objDump == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+#ifdef WINDOWS
+	// make sure there is a .exe extention on the name of objdump
+
+	int l;
+	l = strlen(objDump);
+	if ((l < 4) || (strcasecmp(&objDump[l - 4], ".exe") != 0)) {
+		strcat(objDump, ".exe");
+	}
+#endif // WINDOWS
+
+	// see if a path was included in the name.
+
+	bool hasPath;
+	hasPath = false;
+
+	for (int i = 0; (hasPath == false) && (objDump[i] != 0); i++) {
+		if (objDump[i] == '/') {
+			hasPath = true;
+		}
+		else if (objDump[i] == '\\') {
+			hasPath = true;
+		}
+	}
+
+	//	printf("hasPath: %d\n",hasPath);
+
+	if (hasPath == true) {
+
+		// has a path - don't mess with it
+
+		// still need to see if it exists
+
+#ifdef WINDOWS
+		if (objDump[0] == '/') {
+			if (((objDump[1] >= 'a') && (objDump[1] <= 'z')) ||
+				((objDump[1] >= 'A') && (objDump[1] <= 'Z'))) {
+				if (objDump[2] == '/') {
+					objDump[0] = objDump[1];
+					objDump[1] = ':';
+				}
+			}
+
+		}
+#endif // WINDOWS
+
+		//		printf("try0: %s\n",objDump);
+
+		if (access(objDump, X_OK) == 0) {
+			foundExec = true;
+		}
+
+		//		printf("found: %d\n",foundExec);
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	char objdumpcmd[512];
+	char* riscv_path;
+
+	// try prepending the RISCV_PATH environment variable
+
+	riscv_path = getenv("RISCV_PATH");
+	if (riscv_path != nullptr) {
+		bool unix_path;
+		bool windows_path;
+		char last_char;
+
+		unix_path = false;
+		windows_path = false;
+		last_char = 0;
+
+		strcpy(objdumpcmd, riscv_path);
+
+		// see if there is a terminating path specifyer in the path
+
+		for (int i = 0; riscv_path[i] != 0; i++) {
+			if (riscv_path[i] == '/') {
+				unix_path = true;
+			}
+			else if (riscv_path[i] == '\\') {
+				windows_path = true;
+			}
+			else {
+				last_char = riscv_path[i];
+			}
+		}
+
+		if (windows_path == true) {
+			if (unix_path == true) {
+				printf("Error: findObjDump(): Conflicting path type\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (last_char != '\\') {
+				strcat(objdumpcmd, "\\");
+			}
+		}
+		else if (unix_path == true) {
+			if (last_char != '/') {
+				strcat(objdumpcmd, "/");
+			}
+		}
+
+		strcat(objdumpcmd, objDump);
+
+		//		printf("try1: %s\n",objdumpcmd);
+
+		if (access(objdumpcmd, X_OK) == 0) {
+			strcpy(objDump, objdumpcmd);
+
+			foundExec = true;
+
+			//			printf("found: %d\n",foundExec);
+
+			return TraceDqrProfiler::DQERR_OK;
+		}
+	}
+
+	// see if we can execute objdump with the given name (or path/name)
+
+	char* path;
+	path = getenv("PATH");
+
+	if (path != nullptr) {
+		int s;
+		int e;
+		bool path_sep;
+
+		s = 0;
+		while ((path[s] != 0) && (foundExec == false)) {
+			path_sep = false;
+
+			e = s;
+
+			while ((path[e] != 0) && (path[e] != PATH_SEG_SEP)) {
+				if ((path[e] == '/') || (path[e] == '\\')) {
+					path_sep = true;
+				}
+				else {
+					path_sep = false;
+				}
+				e += 1;
+			}
+
+			// try from start to finish
+
+			char end;
+			end = path[e];
+
+			path[e] = 0;
+			strcpy(objdumpcmd, &path[s]);
+
+			//			printf("path seg: %s\n",objdumpcmd);
+
+						// add name of objdump program to end
+
+			if (path_sep == false) {
+				strcat(objdumpcmd, PATH_SEP);
+			}
+
+			strcat(objdumpcmd, objDump);
+
+			//			printf("trying path %s, %d\n",objdumpcmd,access(objdumpcmd,X_OK));
+
+			if (access(objdumpcmd, X_OK) == 0) {
+				strcpy(objDump, objdumpcmd);
+
+				foundExec = true;
+
+				//				printf("found: %d\n",foundExec);
+			}
+
+			if (end != 0) {
+				s = e + 1;
+			}
+			else {
+				s = e;
+			}
+		}
+
+		if (foundExec == true) {
+			strcpy(objDump, objdumpcmd);
+			return TraceDqrProfiler::DQERR_OK;
+		}
+	}
+
+	// try executing in the current working directory
+
+#ifdef WINDOWS
+	strcpy(objdumpcmd, ".\\");
+#else // WINDOWS
+	strcpy(objdumpcmd, "./");
+#endif // WINDOWS
+
+	strcat(objdumpcmd, objDump);
+
+	//	printf("try3: %s\n",objdumpcmd);
+
+	if (access(objdumpcmd, X_OK) == 0) {
+		foundExec = true;
+
+		strcpy(objDump, objdumpcmd);
+
+		//		printf("found: %d\n",foundExec);
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	//	printf("give up: %d\n",foundExec);
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+#ifdef WINDOWS
+
+TraceDqrProfiler::DQErr ObjDump::execObjDump(const char* elfName, const char* objdumpPath)
+{
+	char cmd[1024];
+	char objdump[512];
+	TraceDqrProfiler::DQErr rc;
+
+	if (objdumpPath == nullptr) {
+		strcpy(objdump, PROFILER_DEFAULTOBJDUMPNAME);
+	}
+	else {
+		strcpy(objdump, objdumpPath);
+	}
+
+	bool foundExec;
+
+	rc = findObjDump(objdump, foundExec);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (foundExec == false) {
+		printf("Error: execObjDump(): Could not find objdump\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	sprintf(cmd, "%s -t -d -h -l %s", objdump, elfName);
+
+	//  printf("cmd: '%s'\n",cmd);
+
+#ifdef WINDOWS
+	SECURITY_ATTRIBUTES sa;
+	sa.nLength = sizeof(sa);
+	sa.lpSecurityDescriptor = NULL;
+	sa.bInheritHandle = TRUE;
+
+	hStdOutPipeRead = NULL;
+	hStdOutPipeWrite = NULL;
+	if (CreatePipe(&hStdOutPipeRead, &hStdOutPipeWrite, &sa, 0) == FALSE)
+	{
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+
+	STARTUPINFO si;
+	DWORD flags = CREATE_NO_WINDOW;
+
+	ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
+	ZeroMemory(&si, sizeof(STARTUPINFO));
+	si.cb = sizeof(STARTUPINFO);
+	si.dwFlags |= STARTF_USESTDHANDLES;
+	si.hStdError = hStdOutPipeWrite;
+	si.hStdOutput = hStdOutPipeWrite;
+	si.hStdInput = NULL;
+
+	if (CreateProcess(NULL, cmd, NULL, NULL, TRUE, flags, NULL, NULL, &si, &pi) == FALSE)
+	{
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// Close pipes we do not need.
+	CloseHandle(hStdOutPipeWrite);
+	hStdOutPipeWrite = NULL;
+#else
+	fpipe = _popen(cmd, "rb");
+	if (fpipe == NULL) {
+		printf("Error: popen(): Failed\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	stdoutPipe = fileno(fpipe);
+	if (stdoutPipe == -1) {
+		printf("Error: fileno(): Failed\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+#endif
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+#else // WINDOWS
+
+TraceDqrProfiler::DQErr ObjDump::execObjDump(const char* elfName, const char* objdumpPath)
+{
+	int rc;
+	bool foundExec;
+
+	char objdump[512];
+
+	if (objdumpPath == nullptr) {
+		strcpy(objdump, PROFILER_DEFAULTOBJDUMPNAME);
+	}
+	else {
+		strcpy(objdump, objdumpPath);
+	}
+
+	rc = findObjDump(objdump, foundExec);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (foundExec == false) {
+		printf("Error: execObjDump(): Could not find objdump\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	pid_t pid;
+
+	// pid == 0 for child process, for parent process, pid is pid of child
+
+	int stdoutPipefd[2];
+
+	rc = pipe(stdoutPipefd);
+	if (rc < 0) {
+		printf("Error: pipe(): failed\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	pid = fork();
+	if (pid == -1) {
+		printf("Error: fork(): failed\n");
+
+		close(stdoutPipefd[0]);
+		close(stdoutPipefd[1]);
+
+		objdumpPid = (pid_t)-1;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (pid != 0) {
+		// parent
+
+		objdumpPid = pid;
+
+		close(stdoutPipefd[1]);
+
+		stdoutPipe = stdoutPipefd[0];
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+	else {
+		// child
+
+		close(stdoutPipefd[0]);
+
+		rc = dup2(stdoutPipefd[1], STDOUT_FILENO);
+		if (rc < 0) {
+			printf("Error: child: dup2(): failed\n");
+
+			close(stdoutPipefd[1]);
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		const char* args[7];
+
+		args[0] = objdump;
+		args[1] = "-t";
+		args[2] = "-d";
+		args[3] = "-h";
+		args[4] = "-l";
+		args[5] = elfName;
+		args[6] = NULL;
+
+		execvp(args[0], (char* const*)args);
+
+		printf("Error: execv(): failed\n");
+
+		close(stdoutPipefd[1]);
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// should never get here
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+#endif // WINDOWS
+
+#ifdef WINDOWS
+TraceDqrProfiler::DQErr ObjDump::fillPipeBuffer()
+{
+	if (pipeEOF) {
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	if (hStdOutPipeRead == NULL) {
+		printf("Error: fillPipeBuffer(): Invalid pipe\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	DWORD dwRead = 0;
+	ReadFile(hStdOutPipeRead, pipeBuffer, sizeof pipeBuffer, &dwRead, NULL);
+	if (dwRead < 0) {
+		printf("Error: fillPipeBuffer(): read() failed\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (dwRead == 0) {
+		pipeEOF = 0;
+		WaitForSingleObject(pi.hProcess, INFINITE);
+		CloseHandle(pi.hProcess);
+		CloseHandle(pi.hThread);
+		CloseHandle(hStdOutPipeRead);
+		hStdOutPipeRead = NULL;
+	}
+
+	endOfBuffer = dwRead;
+	pipeIndex = 0;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+#else
+TraceDqrProfiler::DQErr ObjDump::fillPipeBuffer()
+{
+	int rc;
+
+	if (pipeEOF) {
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	if (stdoutPipe < 0) {
+		printf("Error: fillPipeBuffer(): Invalid pipe\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	rc = read(stdoutPipe, pipeBuffer, sizeof pipeBuffer);
+	if (rc < 0) {
+		printf("Error: fillPipeBuffer(): read() failed\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (rc == 0) {
+		pipeEOF = 0;
+	}
+
+	//{
+	//for (int i = 0; i < rc; i++) {
+	//printf("%c",pipeBuffer[i]);
+	//}
+	//}
+
+	endOfBuffer = rc;
+	pipeIndex = 0;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+#endif
+
+bool ObjDump::isWSLookahead()
+{
+	if (pipeIndex >= endOfBuffer) {
+		// fill buffer
+
+		TraceDqrProfiler::DQErr rc;
+
+		rc = fillPipeBuffer();
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return odtt_error;
+		}
+
+		if (endOfBuffer == 0) {
+			return false;
+		}
+	}
+
+	switch (pipeBuffer[pipeIndex]) {
+	case ' ':
+	case '\t':
+		return true;
+	default:
+		break;
+	}
+
+	return false;
+}
+
+ObjDump::objDumpTokenType ObjDump::getNextLex(char* lex)
+{
+	TraceDqrProfiler::DQErr rc;
+	int haveWS = 1;
+
+	lex[0] = 0;
+
+	// strip WS
+
+	do {
+		while ((pipeIndex < endOfBuffer) && haveWS) {
+			switch (pipeBuffer[pipeIndex]) {
+			case ' ':
+			case '\r':
+			case '\t':
+				pipeIndex += 1;
+				break;
+			default:
+				haveWS = 0;
+				break;
+			}
+		}
+
+		if (haveWS) {
+			// if haveWS is still true, we ran out of chars
+
+			rc = fillPipeBuffer();
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				return odtt_error;
+			}
+
+			if (endOfBuffer == 0) {
+				return odtt_eof;
+			}
+		}
+	} while (haveWS);
+
+	// at this point we have a non-ws char (which could be a '\n')
+
+	// could be a \n, number, symbol, text
+
+	switch (pipeBuffer[pipeIndex]) {
+	case ',':
+		pipeIndex += 1;
+		return odtt_comma;
+	case ':':
+		pipeIndex += 1;
+		return  odtt_colon;
+	case '<':
+		pipeIndex += 1;
+		return  odtt_lt;
+	case '>':
+		pipeIndex += 1;
+		return  odtt_gt;
+	case '(':
+		pipeIndex += 1;
+		return  odtt_lp;
+	case ')':
+		pipeIndex += 1;
+		return  odtt_rp;
+	case '\n':
+		pipeIndex += 1;
+		return  odtt_eol;
+	default:
+		break;
+	}
+
+	int i = 0;
+
+	int haveLex = 0;
+
+	do {
+		while ((pipeIndex < endOfBuffer) && (!haveLex)) {
+			char c;
+			c = pipeBuffer[pipeIndex];
+			switch (c) {
+			case ' ':
+			case '\t':
+			case '\r':
+			case '\n':
+			case ':':
+			case '<':
+			case '>':
+			case ',':
+			case '(':
+			case ')':
+				haveLex = 1;
+				break;
+			default:
+				lex[i] = c;
+				i += 1;
+				pipeIndex += 1;
+				break;
+			}
+		}
+
+		if (!haveLex) {
+			// if haveLex is false, we ran out of chars
+
+			rc = fillPipeBuffer();
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				lex[i] = 0;
+				return odtt_error;
+			}
+
+			if (endOfBuffer == 0) {
+				// this is an eof
+
+				haveLex = 1;
+			}
+		}
+	} while (!haveLex);
+
+	lex[i] = 0;
+
+	return odtt_string;
+}
+
+bool ObjDump::isStringAHexNumber(char* s, uint64_t& n)
+{
+	int validNumber;
+	uint64_t val;
+
+	validNumber = 1;
+	val = 0;
+
+	for (int i = 0; validNumber && (s[i] != 0); i++) {
+		char c;
+
+		c = s[i];
+
+		switch (c) {
+		case '0':
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+			val = val * 16 + (c - '0');
+			break;
+		case 'a':
+		case 'b':
+		case 'c':
+		case 'd':
+		case 'e':
+		case 'f':
+			val = val * 16 + (c - 'a' + 10);
+			break;
+		case 'A':
+		case 'B':
+		case 'C':
+		case 'D':
+		case 'E':
+		case 'F':
+			val = val * 16 + (c - 'A' + 10);
+			break;
+		default:
+			validNumber = 0;
+			break;
+		}
+	}
+
+	if (validNumber) {
+		n = val;
+		return true;
+	}
+
+	return false;
+}
+
+bool  ObjDump::isStringADecNumber(char* s, uint64_t& n)
+{
+	int validNumber;
+	uint64_t val;
+
+	validNumber = 1;
+	val = 0;
+
+	for (int i = 0; validNumber && (s[i] != 0); i++) {
+		char c;
+
+		c = s[i];
+
+		switch (c) {
+		case '0':
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+			val = val * 10 + (c - '0');
+			break;
+		default:
+			validNumber = 0;
+			break;
+		}
+	}
+
+	if (validNumber) {
+		n = val;
+		return true;
+	}
+
+	return false;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseElfName(char* elfName, enum elfType& et)
+{
+	objDumpTokenType type;
+
+	// get the elf file name
+
+	for (int scanning = 1; scanning; ) {
+		type = getNextLex(elfName);
+
+		switch (type) {
+		case odtt_eol:
+			break;
+		case odtt_lt:
+		case odtt_gt:
+		case odtt_lp:
+		case odtt_rp:
+		case odtt_comma:
+		case odtt_number:
+		case odtt_error:
+			printf("Error: parseElfName(): unexpected input\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		case odtt_eof:
+			printf("Error: parseElfName(): EOF encountered\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		case odtt_colon:
+			printf("Error: parseElfName(): unexpected input ':'\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		case odtt_string:
+			scanning = 0;
+			break;
+		}
+	}
+
+	char lex[256];
+
+	type = getNextLex(lex);
+	if (type != odtt_colon) {
+		printf("Error: parseElfName(): expected ':', %d\n", type);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// if the : is followed by white space, we shold look for "file".
+	// Otherwise, continue collecting elf file name
+
+	if (isWSLookahead() == false) {
+		// The colon we found must be a drive specify. Get rest of elf name
+		for (int scanning = 1; scanning; ) {
+			type = getNextLex(lex);
+
+			switch (type) {
+			case odtt_eol:
+				break;
+			case odtt_lt:
+			case odtt_gt:
+			case odtt_lp:
+			case odtt_rp:
+			case odtt_comma:
+			case odtt_number:
+			case odtt_error:
+				printf("Error: parseElfName(): unexpected input\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			case odtt_eof:
+				printf("Error: parseElfName(): EOF encountered\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			case odtt_colon:
+				printf("Error: parseElfName(): unexpected input ':'\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			case odtt_string:
+				scanning = 0;
+				break;
+			}
+		}
+
+		strcat(elfName, ":");
+		strcat(elfName, lex);
+
+		type = getNextLex(lex);
+		if (type != odtt_colon) {
+			printf("Error: parseElfName(): expected ':', %d\n", type);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	// get the elf file format
+
+	lex[0] = 0;
+
+	type = getNextLex(lex);
+	if ((type != odtt_string) || (strcasecmp("file", lex) != 0)) {
+		printf("Error: parseElfName(): expected 'file'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if ((type != odtt_string) || (strcasecmp("format", lex) != 0)) {
+		printf("Error: parseElfName(): expected 'format'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseElfName(): execpted elf file format specifier\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (strcasecmp("elf64-littleriscv", lex) == 0) {
+		et = elfType_64_little;
+	}
+	else if (strcasecmp("elf32-littleriscv", lex) == 0) {
+		et = elfType_32_little;
+	}
+	else {
+		printf("Error: parseElfName(): invalid elf file type\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseSection(objDumpTokenType& nextType, char* nextLex, Section*& codeSection)
+{
+	objDumpTokenType type;
+	char lex[256];
+	char name[256];
+	uint64_t n;
+
+	// parse sequence number
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		// this is not an error (yet). We may have reached the end of the section list
+
+		nextType = type;
+		strcpy(nextLex, lex);
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	if (isStringADecNumber(lex, n) == false) {
+		// this is not an error (yet). We may have reached the end of the section list
+
+		nextType = type;
+		strcpy(nextLex, lex);
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	// parse section name
+
+	type = getNextLex(name);
+	if (type != odtt_string) {
+		printf("Error: parseSection(): Expected section name\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// parse section size
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseSection(): Expected section size\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (isStringAHexNumber(lex, n) == false) {
+		printf("Error: parseSection(): Expected section size. Not a valid hex number '%s'\n", lex);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	uint32_t sec_size;
+	sec_size = (uint32_t)n;
+
+	// parse section VMA
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseSection(): Expected section VMA\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (isStringAHexNumber(lex, n) == false) {
+		printf("Error: parseSection(): Expected section VMA. Not a valid hex number '%s'\n", lex);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	uint64_t vma = n;
+
+	// parse section LMA
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseSection(): Expected section LMA\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (isStringAHexNumber(lex, n) == false) {
+		printf("Error: parseSection(): Expected section LMA. Not a valid hex number '%s'\n", lex);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// parse section file offset
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseSection(): Expected section file offset\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (isStringAHexNumber(lex, n) == false) {
+		printf("Error: parseSection(): Expected section file offset. Not a valid hex number '%s'\n", lex);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	uint32_t file_offset;
+	file_offset = (uint32_t)n;
+
+	// parse section alignment
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseSection(): Expected section file offset\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// check for valid alignment
+
+	uint32_t align;
+
+    if (strcmp("2**0",lex) == 0) {
+		align = 1 << 0;
+	}
+    else if (strcmp("2**1",lex) == 0) {
+		align = 1 << 1;
+	}
+    else if (strcmp("2**2",lex) == 0) {
+		align = 1 << 2;
+	}
+    else if (strcmp("2**3",lex) == 0) {
+		align = 1 << 3;
+	}
+    else if (strcmp("2**4",lex) == 0) {
+		align = 1 << 4;
+	}
+    else if (strcmp("2**5",lex) == 0) {
+		align = 1 << 5;
+	}
+    else if (strcmp("2**6",lex) == 0) {
+		align = 1 << 6;
+	}
+    else if (strcmp("2**7",lex) == 0) {
+		align = 1 << 7;
+	}
+    else if (strcmp("2**8",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**9",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**10",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**11",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**12",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**13",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**14",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**15",lex) == 0) {
+		align = 1 << 8;
+	}
+    else if (strcmp("2**16",lex) == 0) {
+		align = 1 << 8;
+	}
+	else {
+		printf("Error: parseSection(): Invalid section alignment: %s\n", lex);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_eol) {
+		printf("Error: parseSection(): Expected EOL\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	uint32_t flags = 0;
+
+	do {
+		type = getNextLex(lex);
+		if (type != odtt_string) {
+			printf("Error: parseSection(): Expected string\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if (strcasecmp("CONTENTS", lex) == 0) {
+			// set CONTENTS flag
+			flags |= Section::sect_CONTENTS;
+		}
+		else if (strcasecmp("ALLOC", lex) == 0) {
+			// set ALLOC flag
+			flags |= Section::sect_ALLOC;
+		}
+		else if (strcasecmp("LOAD", lex) == 0) {
+			// set LOAD flag
+			flags |= Section::sect_LOAD;
+		}
+		else if (strcasecmp("READONLY", lex) == 0) {
+			// set READONLY flag
+			flags |= Section::sect_READONLY;
+		}
+		else if (strcasecmp("DATA", lex) == 0) {
+			// set DATA flag
+			flags |= Section::sect_DATA;
+		}
+		else if (strcasecmp("CODE", lex) == 0) {
+			// set CODE flag
+			flags |= Section::sect_CODE;
+		}
+		else if (strcasecmp("THREAD_LOCAL", lex) == 0) {
+			// set THREAD_LOCAL flag
+			flags |= Section::sect_THREADLOCAL;
+		}
+		else if (strcasecmp("DEBUGGING", lex) == 0) {
+			// set DEBUGGING flag
+			flags |= Section::sect_DEBUGGING;
+		}
+		else if (strcasecmp("OCTETS", lex) == 0) {
+			// set OCTETS flag
+			flags |= Section::sect_OCTETS;
+		}
+		else {
+			printf("Error: parseSection(): Expected valid section flag: %s\n", lex);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+		if ((type != odtt_comma) && (type != odtt_eol)) {
+			printf("Error: parseSection(): Expected comma or eol: %d\n", type);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	} while ((type != odtt_eol) && (type != odtt_eof));
+
+    if ((flags & Section::sect_CODE) || (strcmp(".comment",name) == 0)) {
+		// create new section
+		Section* sp = new Section();
+
+		strcpy(sp->name, name);
+		sp->flags = flags;
+		sp->size = sec_size;
+		sp->offset = file_offset;
+		sp->align = align;
+		sp->startAddr = vma;
+		sp->endAddr = vma + sec_size - 1;
+
+		codeSection = sp;
+	}
+	else {
+		codeSection = nullptr;
+	}
+
+	nextType = type;
+	strcpy(nextLex, lex);
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseSectionList(ObjDump::objDumpTokenType& nextType, char* nextLex, Section*& codeSectionLst)
+{
+	objDumpTokenType type;
+	char lex[256];
+
+	// strip all EOLs
+
+	do {
+		type = getNextLex(lex);
+	} while (type == odtt_eol);
+
+	if ((type != odtt_string) || (strcasecmp("Sections", lex) != 0)) {
+		// no sections: section
+
+		nextType = type;
+		strcpy(nextLex, lex);
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_colon) {
+		printf("Error: parseSectionList(): expected ':' on Sections line\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_eol) {
+		printf("Error: parseSectionList(): extra input on Sections line\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	const char* expected[] = {
+		"Idx",
+		"Name",
+		"Size",
+		"VMA",
+		"LMA",
+		"File",
+		"off",
+		"Algn"
+	};
+
+	for (int i = 0; i < (int)(sizeof expected / sizeof expected[0]); i++) {
+		type = getNextLex(lex);
+
+		if ((type != odtt_string) || (strcasecmp(expected[i], lex) != 0)) {
+			printf("Error: parseSectionList(): expected '%s'\n", expected[i]);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	type = getNextLex(lex);
+
+	if (type != odtt_eol) {
+		printf("Error: parseSectionList(): expected eol\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	do {
+		Section* newSection;
+		TraceDqrProfiler::DQErr rc;
+
+		rc = parseSection(type, lex, newSection);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			printf("Error: parseSectionList(): parseSection() failed\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if (newSection != nullptr) {
+			newSection->next = codeSectionLst;
+			codeSectionLst = newSection;
+		}
+	} while (type == odtt_eol);
+
+	nextType = type;
+	strcpy(nextLex, lex);
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+ObjDump::objDumpTokenType ObjDump::getRestOfLine(char* lex)
+{
+	TraceDqrProfiler::DQErr rc;
+	int haveWS = 1;
+
+	lex[0] = 0;
+
+	// strip WS
+
+	do {
+		while ((pipeIndex < endOfBuffer) && haveWS) {
+			switch (pipeBuffer[pipeIndex]) {
+			case ' ':
+			case '\r':
+			case '\t':
+				pipeIndex += 1;
+				break;
+			default:
+				haveWS = 0;
+				break;
+			}
+		}
+
+		if (haveWS) {
+			// if haveWS is still true, we ran out of chars
+
+			rc = fillPipeBuffer();
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				return odtt_error;
+			}
+
+			if (endOfBuffer == 0) {
+				return odtt_eof;
+			}
+		}
+	} while (haveWS);
+
+	// at this point we have a non-ws char (which could be a '\n')
+
+	// copy chars until eof or eol
+
+	if (pipeBuffer[pipeIndex] == '\n') {
+		pipeIndex += 1;
+		return  odtt_eol;
+	}
+
+	int i = 0;
+
+	int haveLex = 0;
+
+	do {
+		while ((pipeIndex < endOfBuffer) && (!haveLex)) {
+			char c;
+			c = pipeBuffer[pipeIndex];
+			switch (c) {
+			case '\n':
+				haveLex = 1;
+				break;
+			case '\r':
+				pipeIndex += 1;
+				break;
+			default:
+				lex[i] = c;
+				i += 1;
+				pipeIndex += 1;
+				break;
+			}
+		}
+
+		if (!haveLex) {
+			// if haveLex is false, we ran out of chars
+
+			rc = fillPipeBuffer();
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				lex[i] = 0;
+				return odtt_error;
+			}
+
+			if (endOfBuffer == 0) {
+				// this is an eof
+
+				lex[i] = 0;
+				return odtt_eof;
+			}
+		}
+	} while (!haveLex);
+
+	lex[i] = 0;
+
+	return odtt_eol;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseFileOrLabelOrDisassembly(line_t& lineType, char* text, int& length, uint32_t& value)
+{
+	objDumpTokenType type;
+	char lex[256];
+	uint64_t n;
+
+	// already have hex number
+
+	//	could be:
+	//
+	// 2  address '<' label '>' ':'				<- Hstring '<' string '>' ':' EOL
+	//
+	// 3  address ':' instruction disassembly	<- Hstring ':' Hstring string2end EOL
+	//
+	// 4  drive ':' path-file ':' line			<- [H]string ':' string ':' Dstring EOL
+	//
+	// 5  name '(' ')' ':'						<- string '(' ')' ':' EOL
+
+	type = getNextLex(lex);
+
+	if (type == odtt_lt) {
+		// case 2: address '<' label '>' ':'
+
+		lineType = line_t_label;
+
+		type = getNextLex(text);
+		if (type != odtt_string) {
+			printf("Error: parseFileOrLabelOrDisassembly(): expected label\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+		if (type != odtt_gt) {
+			printf("Error: parseFileOrLabelOrDisassembly(): expected '>'\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+		if (type != odtt_colon) {
+			printf("Error: parseFileOrLabelOrDisassembly(): expected ':'\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+	}
+	else if (type == odtt_lp) {
+		// case 5: name '(' ')' ':'
+
+		lineType = line_t_func;
+
+		type = getNextLex(lex);
+		if (type != odtt_rp) {
+			printf("Error: parseFileOrLabelOrDisassembly(): expected ')'\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+		if (type != odtt_colon) {
+			printf("Error: parseFileOrLabelOrDisassembly(): expected ':'\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+	}
+	else if (type == odtt_colon) {
+		// need to look further to figure out what we have
+
+		type = getNextLex(text);
+		if (type != odtt_string) {
+			printf("Error: parseFileOrLabelOrDisassembly(): Expected instruction or path\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if (isStringAHexNumber(text, n) == false) {
+			// have a filepath:line
+
+			lineType = line_t_path;
+
+			type = getNextLex(lex);
+			if (type != odtt_colon) {
+				printf("Error: parseFileOrLabelOrDisassembly(): Expected ':'\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			type = getNextLex(lex);
+			if (type != odtt_string) {
+				printf("Error: parseFileOrLabelOrDisassembly(): Expected line number\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (isStringADecNumber(lex, n) == false) {
+				// this might be a weird objdump double path (thank you objdump - NOT).
+
+				// Discard text and copy lex to text
+				strcpy(text, lex);
+
+				type = getNextLex(lex);
+				if (type != odtt_colon) {
+					printf("Error: parseFileOrLabelOrDisassembly(): Expected line number after double path\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				// need to get the line number
+
+				type = getNextLex(lex);
+				if (type != odtt_string) {
+					printf("Error: parseFileOrLabelOrDisassembly(): Expected line number\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				if (isStringADecNumber(lex, n) == false) {
+					printf("Error: parseFileOrLabelOrDisassembly(): Expected line number\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+			}
+
+			value = (uint32_t)n;
+
+			// see if we have '(' discriminator n ')'
+
+			type = getNextLex(lex);
+			if (type == odtt_lp) {
+				type = getNextLex(lex);
+				if (type != odtt_string) {
+					printf("Error: parseFileOrLabelOrDisassembly(): Expected discriminator\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				type = getNextLex(lex);
+				if (type != odtt_string) {
+					printf("Error: parseFileOrLabelOrDisassembly(): Expected discriminator number\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				type = getNextLex(lex);
+				if (type != odtt_rp) {
+					printf("Error: parseFileOrLabelOrDisassembly(): Expected discriminator ')'\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				type = getNextLex(lex);
+			}
+		}
+		else {
+			//  have a disassembly line
+
+			lineType = line_t_diss;
+
+			value = (uint32_t)n;
+
+			int len;
+			len = strlen(text);
+
+			if (len == 4) {
+				length = 16;
+			}
+			else if (len == 8) {
+				length = 32;
+			}
+			else {
+				printf("Error: pareFileOrLabelOrDisassembly(): Invalid instruction (%s,%d)\n", text, len);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			type = getRestOfLine(text);
+			if ((type == odtt_eof) || (type == odtt_eol)) {
+				return TraceDqrProfiler::DQERR_OK;
+			}
+		}
+	}
+	else {
+		printf("Error: parseFileOrLabelOrDisassembly(): Unexpected input (%d, %s, %s)\n", type, text, lex);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if ((type != odtt_eol) && (type != odtt_eof)) {
+		printf("Error: parseFileOrLabelOrDisassembly(): Expected EOL\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseFileLine(uint32_t& line)
+{
+	enum objDumpTokenType type;
+	char lex[256];
+	uint64_t n;
+
+	// already have filename when we enter this func
+
+	type = getNextLex(lex);
+	if (type != odtt_colon) {
+		printf("Error: parseFileLine(): Expected ':'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if ((type != odtt_string) || (isStringADecNumber(lex, n) == 0)) {
+		printf("Error: parseFileLine(): Expected line number\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	line = (uint32_t)n;
+
+	type = getNextLex(lex);
+
+	// check for (discriminator n)
+
+	if (type == odtt_lp) {
+		// have (discriminator n)
+		type = getNextLex(lex);
+		if ((type != odtt_string) || (strcasecmp("discriminator", lex) != 0)) {
+			printf("Error: parseFileLine(): Expected discriminator\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+		if ((type != odtt_string) || (isStringADecNumber(lex, n) == 0)) {
+			printf("Error: parseFileLine(): Expected discriminator number\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+		if (type != odtt_rp) {
+			printf("Error: parseFileLine(): Expected ')'\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		type = getNextLex(lex);
+	}
+
+	if ((type != odtt_eol) && (type != odtt_eof)) {
+		printf("Error: parseFileLine(): Extra input on end of line. Expected EOL (%d)\n", type);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseFuncName()
+{
+	enum objDumpTokenType type;
+	char lex[256];
+
+	// should be string ( ^ ) : eol
+
+	type = getNextLex(lex);
+	if (type != odtt_rp) {
+		printf("Error: parseFuncName(): Expected ')'\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_colon) {
+		printf("Error: parseFuncName(): Expected ':'\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if ((type != odtt_eol) && (type != odtt_eof)) {
+		printf("Error: parseFuncName(): Expected EOL (%d)\n", type);
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseDisassemblyList(objDumpTokenType& nextType, char* nextLex, Section* codeSectionLst, SrcFileRoot& srcFileRoot)
+{
+	objDumpTokenType type;
+	char lex[1024];
+	char lex2[1024];
+	TraceDqrProfiler::DQErr rc;
+	Section* sp;
+
+	type = getNextLex(lex);
+	if ((type != odtt_string) || (strcasecmp("of", lex) != 0)) {
+		printf("Error: parseDisassemblyList(): Expected 'of'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if ((type != odtt_string) || (strcasecmp("section", lex) != 0)) {
+		printf("Error: parseDisassemblyList(): Expected 'section'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseDisassemblyList(): Expected section name\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	sp = codeSectionLst->getSectionByName(lex);
+	if (sp == nullptr) {
+		printf("Error: parseDisassemblyList(): Section '%s' not found\n", lex);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (sp->code == nullptr) {
+		sp->code = new uint16_t[(sp->size + 1) / 2]; // don't need to init to 0's
+	}
+
+	if (sp->diss == nullptr) {
+		sp->diss = new char* [(sp->size + 1) / 2];
+		for (int i = 0; i < (int)(sp->size + 1) / 2; i++) {
+			sp->diss[i] = nullptr;
+		}
+	}
+
+	if (sp->line == nullptr) {
+		sp->line = new uint32_t[(sp->size + 1) / 2];
+		for (int i = 0; i < (int)(sp->size + 1) / 2; i++) {
+			sp->line[i] = 0;
+		}
+	}
+
+	if (sp->fName == nullptr) {
+		sp->fName = new char* [(sp->size + 1) / 2];
+		for (int i = 0; i < (int)(sp->size + 1) / 2; i++) {
+			sp->fName[i] = nullptr;
+		}
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_colon) {
+		printf("Error: parseDisassemblyList(): Expected ':'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_eol) {
+		printf("Error: parseDisassemblyList(): Expected EOL\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// now at start of disassembly
+
+	char* fName = nullptr;
+	uint32_t line = 0;
+
+	for (;;) {
+		int eol_count = 0;
+
+		while (type == odtt_eol) {
+			eol_count += 1;
+			type = getNextLex(lex);
+		}
+
+		if ((type != odtt_string) && (type != odtt_lt)) {
+			nextType = type;
+			strcpy(nextLex, lex);
+
+			return TraceDqrProfiler::DQERR_OK;
+		}
+
+		line_t lineType;
+		int length;
+		uint32_t value;
+		uint64_t addr;
+
+		// have a string or '<' (case 2)
+
+		// 1  ...									<- string EOL
+		//
+		// 2  '<' 'unknown' '>' ':' line			<- '<' string '>' ':' Dstring EOL
+		//
+		// 2.1 address '<' label '>' ':'			<- Hstring '<' string '>' ':' EOL
+		//
+		// 3  address ':' instruction disassembly	<- Hstring ':' Hstring string2end EOL
+		//
+		// 4  drive ':' path-file ':' line		<- [H]string ':' string ':' Dstring EOL
+		//
+		// 5  function '(' ')' ':'				<- string '(' ')' ':' EOL
+		//
+		// 6  disassembly of section label :		<- string string string string ':' EOL
+		//
+		// 7  symbol table ':'					<- string string ':' EOL
+		//
+
+		// want to only look ahead one lex!
+
+		if (type == odtt_lt) { // case 2
+			type = getNextLex(lex);
+			if (type != odtt_string) {
+				printf("Error: parseDisassemblyList(): Expected '<' to be followed by unknown\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+          if (strcmp(lex,"unknown") != 0) {
+				printf("Error: parseDisassemblyList(): Expected '<' to be followed by unknown\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			type = getNextLex(lex);
+			if (type != odtt_gt) {
+				printf("Error: parseDisassemblyList(): Expected '<unknown' to be followed by '>'\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			type = getNextLex(lex);
+			if (type != odtt_colon) {
+				printf("Error: parseDisassemblyList(): Expected '<unknown>' to be followed by ':'\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			type = getNextLex(lex);
+			if (type != odtt_string) {
+				printf("Error: parseDisassemblyList(): Expected '<unknown>:' to be followed by line number\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			uint64_t val;
+
+			if (isStringADecNumber(lex, val) == false) {
+				printf("Error: parseDisassemblyList(): Expected '<unknown>:' to be followed by line number\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			type = getNextLex(lex);
+			if (type != odtt_eol) {
+				printf("Error: parseDisassemblyList(): Expected '<unknown>:line' to be followed by EOL\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			fName = nullptr;
+			line = 0;
+
+			// just skip and do next line
+		}
+      else if (strcmp("...",lex) == 0) { // case 1
+			type = getNextLex(lex);
+			if (type != odtt_eol) {
+				printf("Error: parseDisassemblyList(): Expected '...' to be folowed by EOL\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			fName = nullptr;
+			line = 0;
+
+			// just skip and do next line
+		}
+		else if (isStringAHexNumber(lex, addr) == true) { // cases 2.1, 3, and sometimes 4
+			rc = parseFileOrLabelOrDisassembly(lineType, lex, length, value);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: parseDisassemblyList(): parseDisassembly() failed\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			switch (lineType) {
+			case line_t_label:
+				// currently, don't use anyting from address < label > :
+				// but this information could be added to sym table in place of reading the sym table?
+				fName = nullptr;
+				line = 0;
+				break;
+			case line_t_diss:
+				int index;
+				index = (addr - sp->startAddr) / 2;
+
+				sp->code[index] = (uint16_t)value;
+				if (length == 32) {
+					sp->code[index + 1] = (uint16_t)(value >> 16);
+				}
+
+				int len;
+				len = strlen(lex) + 1;
+
+				sp->diss[index] = new char[len];
+				strcpy(sp->diss[index], lex);
+
+				// save file and line here. They are set below and remain valid until they are updated
+
+				sp->fName[index] = fName;
+				sp->line[index] = line;
+				break;
+			case line_t_path:
+				sprintf(lex2, "%X:%s", (uint32_t)addr, lex);
+				fName = srcFileRoot.addFile(lex2);
+				line = value;
+				break;
+			case line_t_func:
+				// if we get here, function name could be interpreted as number, but it shouln't be (such as f1())
+				fName = nullptr;
+				line = 0;
+				break;
+			}
+		}
+		else if ((eol_count > 0) && ((strcasecmp("disassembly", lex) == 0) || (strcasecmp("symbol", lex) == 0))) {	// case 6, 7
+			nextType = type;
+			strcpy(nextLex, lex);
+
+			return TraceDqrProfiler::DQERR_OK;
+		}
+		else if ((lex[0] == '/') || (lex[0] == '\\')) { // more case 4;
+			rc = parseFileLine(line);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: parseDisassemblyList(): parseFileLine() failed\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			fName = srcFileRoot.addFile(lex);
+		}
+		else {	// case 5, reset of case 4
+			// have a string. look ahead and see if it is a '(', ':' (case 5, rest of case 4)
+
+			rc = parseFileOrLabelOrDisassembly(lineType, lex2, length, value);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: parseDisassemblyList(): parseDisassembly() failed\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			switch (lineType) {
+			case line_t_label:
+				printf("Error: parseDisassemblyList(): Bad label\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			case line_t_diss:
+				printf("Error: parseDisassemblyList(): Bad disassembly\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			case line_t_path: // case 4
+				strcat(lex, ":");
+				strcat(lex, lex2);
+				fName = srcFileRoot.addFile(lex2);
+				line = value;
+				break;
+			case line_t_func: // case 5
+				// nothing to do. If we saved the function, would we need to even collect the symtable? Probably.
+				fName = nullptr;
+				line = 0;
+				break;
+			}
+		}
+
+		type = getNextLex(lex);
+	}
+
+	// should never get here
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseFixedField(uint32_t& flags)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	flags = 0;
+
+	// skip first space
+
+	if (pipeIndex >= endOfBuffer) {
+		rc = fillPipeBuffer();
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			printf("Error: parseFixedField(): fillPipeBuffer() failed\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	if (endOfBuffer == 0) {
+		// EOF
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (pipeBuffer[pipeIndex] != ' ') {
+		printf("Error: parseFixedField(): Expected ' '.\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	pipeIndex += 1;
+
+	char flagChars[7];
+
+	for (int i = 0; i < 7; i++) {
+		if (pipeIndex >= endOfBuffer) {
+			rc = fillPipeBuffer();
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: parseFixedField(): fillPipeBuffer() failed\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+		}
+
+		if (endOfBuffer == 0) {
+			// EOF
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		flagChars[i] = pipeBuffer[pipeIndex];
+		pipeIndex += 1;
+	}
+
+	// group 1
+
+	if (flagChars[0] == ' ') {
+		// neither global or local
+	}
+	else if (flagChars[0] == 'l') {
+		flags |= Sym::symLocal;
+	}
+	else if (flagChars[0] == 'g') {
+		flags |= Sym::symGlobal;
+	}
+	else if (flagChars[0] == 'u') {
+		flags |= Sym::symGlobal;
+	}
+	else if (flagChars[0] == '!') {
+		flags |= Sym::symLocal | Sym::symGlobal;
+	}
+	else {
+		printf("Error: parseFixedField(): Invalid sym flag '%c'\n", flagChars[0]);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// group 2
+
+	if (flagChars[1] == ' ') {
+		// strong by default
+	}
+	else if (flagChars[1] == 'w') {
+		flags |= Sym::symWeak;
+	}
+	else {
+		printf("Error: parseFixedField(): Invalid sym flag '%c'\n", flagChars[1]);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// group 3
+
+	if (flagChars[2] == ' ') {
+		// not a contstructor
+	}
+	else if (flagChars[2] == 'C') {
+		flags |= Sym::symConstructor;
+	}
+	else {
+		printf("Error: parseFixedField(): Invalid sym flag '%c'\n", flagChars[2]);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// group 4
+
+	if (flagChars[3] == ' ') {
+		// nothing to do
+	}
+	else if (flagChars[3] == 'W') {
+		// nothing to do
+	}
+	else {
+		printf("Error: parseFixedField(): Invalid sym flag '%c'\n", flagChars[3]);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// group 5
+
+	if (flagChars[4] == ' ') {
+		// not indirect or indirect func
+	}
+	else if (flagChars[4] == 'I') {
+		flags |= Sym::symIndirect;
+	}
+	else if (flagChars[4] == 'i') {
+		flags |= Sym::symIndirectFunc;
+	}
+	else {
+		printf("Error: parseFixedField(): Invalid sym flag '%c'\n", flagChars[4]);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// group 6
+
+	if (flagChars[5] == ' ') {
+		// nothing to do
+	}
+	else if (flagChars[5] == 'd') {
+		flags |= Sym::symDebug;
+	}
+	else if (flagChars[5] == 'D') {
+		flags |= Sym::symDynamic;
+	}
+	else {
+		printf("Error: parseFixedField(): Invalid sym flag '%c'\n", flagChars[5]);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// group 7
+
+	if (flagChars[6] == ' ') {
+		// nothing to do
+	}
+	else if (flagChars[6] == 'F') {
+		flags |= Sym::symFunc;
+	}
+	else if (flagChars[6] == 'f') {
+		flags |= Sym::symFile;
+	}
+	else if (flagChars[6] == 'O') {
+		flags |= Sym::symObj;
+	}
+	else {
+		printf("Error: parseFixedField(): Invalid sym flag '%c'\n", flagChars[6]);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseSymbol(bool& haveSym, char* secName, char* symName, uint32_t& symFlags, uint64_t& symSize)
+{
+	TraceDqrProfiler::DQErr rc;
+	objDumpTokenType type;
+	char lex[256];
+
+	// we have already parsed the sym address
+
+	// Get sym Flags
+
+	haveSym = false;
+
+	rc = parseFixedField(symFlags);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// Get symbol section name
+
+	type = getNextLex(secName);
+	if (type != odtt_string) {
+		printf("Error: parseSymbol(): Expected symbol section name\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// Get symbol alignment or size
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseSymbol(): Expected symbol alignment or size\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (isStringAHexNumber(lex, symSize) == false) {
+		printf("Error: parseSymbol(): Expected a number for alignment or size\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// Get symbol name or special flag
+
+	type = getNextLex(symName);
+	if (type != odtt_eol) { // if eol, there is no name, and we can skip
+		if (type != odtt_string) {
+			printf("Error: parseSymbol(): Expected symbol name or special type (%d)\n", type);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		// Get EOL or symbol name
+
+		type = getNextLex(lex);
+		if (type == odtt_string) {
+			strcpy(symName, lex);
+			type = getNextLex(lex);
+			if (type != odtt_eol) {
+				printf("Error: parseSymbol(): Expected EOL\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+		}
+		else if (type == odtt_colon) {
+			type = getNextLex(lex);
+			if (type != odtt_string) {
+				printf("Error: parseSymbol(): Expected path string\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			strcat(symName, ":");
+			strcat(symName, lex);
+
+			type = getNextLex(lex);
+			if (type != odtt_eol) {
+				printf("Error: parseSymbol(): Expected EOL\n");
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+		}
+		else if (type != odtt_eol) {
+			printf("Error: parseSymbol(): Expected EOL\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		haveSym = true;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseSymbolTable(objDumpTokenType& nextType, char* nextLex, Sym*& syms, Section*& codeSectionLst)
+{
+	objDumpTokenType type;
+	char lex[256];
+	TraceDqrProfiler::DQErr rc;
+
+	type = getNextLex(lex);
+	if (type != odtt_string) {
+		printf("Error: parseSymboTable(): Expected 'TABLE'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (strcasecmp("table", lex) != 0) {
+		printf("Error: parseSymboTable(): Expected 'TABLE'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_colon) {
+		printf("Error: parseSymboTable(): Expected ':'\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	type = getNextLex(lex);
+	if (type != odtt_eol) {
+		printf("Error: parseSymboTable(): Expected EOL\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// now at start of symbols
+
+	uint64_t addr;
+	Sym* file;
+
+	file = nullptr;
+
+	for (;;) {
+		// skip any extra eols
+
+		do {
+			type = getNextLex(lex);
+		} while (type == odtt_eol);
+
+		// Get Symbol address
+
+		if (type != odtt_string) {
+			printf("Error: parseSymbolTable(): Bad input found looking for symbol address\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if (isStringAHexNumber(lex, addr) == false) {
+			// end of symbols
+			nextType = type;
+			strcpy(nextLex, lex);
+
+			return TraceDqrProfiler::DQERR_OK;
+		}
+
+		bool haveSym;
+		char secName[256];
+		char symName[256];
+		uint64_t symSize;
+		uint32_t symFlags;
+
+		haveSym = false;
+
+		rc = parseSymbol(haveSym, secName, symName, symFlags, symSize);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if (haveSym) {
+			Sym* sp;
+			sp = new Sym();
+
+			sp->next = syms;
+			sp->name = new char[strlen(symName) + 1];
+			strcpy(sp->name, symName);
+			sp->flags = symFlags;
+			sp->address = addr;
+			sp->size = symSize;
+
+			if (symFlags & Sym::symFile) {
+				file = sp;
+				sp->srcFile = nullptr;
+			}
+			else if ((symFlags != Sym::symLocal) && (symFlags != (Sym::symLocal | Sym::symFunc))) {
+				// if not local flag, turn off srcFile setting
+				file = nullptr;
+			}
+			else {
+				sp->srcFile = file;
+			}
+
+			Section* sec;
+			sec = codeSectionLst->getSectionByName(secName);
+			sp->section = sec;
+
+			syms = sp;
+		}
+		else if (symFlags & Sym::symFile) {
+			file = nullptr;
+		}
+	}
+
+	// should never get here
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr ObjDump::parseObjdump(int& archSize, Section*& codeSectionLst, Sym*& symLst, SrcFileRoot& srcFileRoot)
+{
+	TraceDqrProfiler::DQErr rc;
+	objDumpTokenType type;
+	char lex[256];
+	char elfName[256];
+	elfType et;
+
+	rc = parseElfName(elfName, et);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: parseObjdump(): expected file name and type\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	switch (et) {
+	case elfType_unknown:
+		printf("Error: parseObjDump(): Unknown elf file type\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	case elfType_64_little:
+		archSize = 64;
+		break;
+	case elfType_32_little:
+		archSize = 32;
+		break;
+	}
+
+	rc = parseSectionList(type, lex, codeSectionLst);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: parseObjdump(): parseSectionList() failed\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// strip out eols until we get something else
+
+	while (type == odtt_eol) {
+		type = getNextLex(lex);
+	}
+
+	// below should loop until error or eof
+
+	while (type == odtt_string) {
+		if (strcasecmp("disassembly", lex) == 0) {
+			rc = parseDisassemblyList(type, lex, codeSectionLst, srcFileRoot);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+		}
+		else if (strcasecmp("symbol", lex) == 0) {
+			rc = parseSymbolTable(type, lex, symLst, codeSectionLst);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+		}
+		else {
+			printf("Error: parseObjdump(): Unexpected input in stream: '%s'\n", lex);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	if (type != odtt_eof) {
+		printf("Error: parseObjdump(): unexpected stuff in input %d\n", type);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+SrcFile::SrcFile(char* fName, SrcFile* nxt)
+{
+	int len;
+	len = strlen(fName) + 1;
+
+	file = new char[len];
+	strcpy(file, fName);
+
+	next = nxt;
+}
+
+SrcFile::~SrcFile()
+{
+	if (file != nullptr) {
+		delete[] file;
+		file = nullptr;
+	}
+
+	next = nullptr;
+}
+
+SrcFileRoot::SrcFileRoot()
+{
+	fileRoot = nullptr;
+}
+
+SrcFileRoot::~SrcFileRoot()
+{
+	SrcFile* srcFile;
+
+	srcFile = fileRoot;
+
+	while (srcFile != nullptr) {
+		SrcFile* next;
+		next = srcFile->next;
+		delete srcFile;
+		srcFile = next;
+	}
+
+	fileRoot = nullptr;
+}
+
+char* SrcFileRoot::addFile(char* fName)
+{
+	if (fName == nullptr) {
+		printf("Error: SrcFile::AddFile(): Null fName argument\n");
+		return nullptr;
+	}
+
+	SrcFile* srcFile = fileRoot;
+
+	for (bool found = false; (srcFile != nullptr) && (found == false);) {
+		if (strcmp(srcFile->file,fName) == 0) {
+			found = true;
+		}
+		else {
+			srcFile = srcFile->next;
+		}
+	}
+
+	if (srcFile == nullptr) {
+		srcFile = new SrcFile(fName, fileRoot);
+		fileRoot = srcFile;
+	}
+
+	return srcFile->file;
+}
+
+void SrcFileRoot::dump()
+{
+	for (SrcFile* sfp = fileRoot; sfp != nullptr; sfp = sfp->next) {
+		printf("sfp: 0x%08llx, file: 0x%08llx %s, next: 0x%08llx\n", sfp, sfp->file, sfp->file, sfp->next);
+	}
+}
+
+ElfReader::ElfReader(const char* elfname, const char* odExe)
+{
+	status = TraceDqrProfiler::DQERR_OK;
+	symtab = nullptr;
+	codeSectionLst = nullptr;
+	elfName = nullptr;
+
+	if (elfname == nullptr) {
+		printf("Error: ElfReader::ElfReader(): No elf file name specified\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	int len = strlen(elfname) + 1;
+	elfName = new char[len];
+	strcpy(elfName, elfname);
+
+	Sym* symLst = nullptr;
+
+	ObjDump* objdump = new ObjDump(elfname, odExe, archSize, codeSectionLst, symLst, srcFileRoot);
+	if (objdump->getStatus() != TraceDqrProfiler::DQERR_OK) {
+		delete objdump;
+		objdump = nullptr;
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	delete objdump;
+	objdump = nullptr;
+
+	switch (archSize) {
+	case 32:
+		bitsPerAddress = 32;
+		break;
+	case 64:
+		bitsPerAddress = 64;
+		break;
+	}
+
+	symtab = new Symtab(symLst);
+
+	TraceDqrProfiler::DQErr rc;
+
+	rc = fixupSourceFiles(codeSectionLst, symLst);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	status = TraceDqrProfiler::DQERR_OK;
+}
+
+ElfReader::~ElfReader()
+{
+	if (elfName != nullptr) {
+		delete[] elfName;
+		elfName = nullptr;
+	}
+
+	if (symtab != nullptr) {
+		// elfReader is the only objet that really owns the Symtab, and is the only object that should
+		// delete it!
+
+		delete symtab;
+		symtab = nullptr;
+	}
+
+	while (codeSectionLst != nullptr) {
+		Section* nextSection = codeSectionLst->next;
+		delete codeSectionLst;
+		codeSectionLst = nextSection;
+	}
+}
+
+TraceDqrProfiler::DQErr ElfReader::fixupSourceFiles(Section* sections, Sym* syms)
+{
+	// iterate through the symbols looking for non-null srcFile field and add it to fName[index].
+
+	for (Sym* sym = syms; sym != nullptr; sym = sym->next) {
+		if (sym->srcFile != nullptr) {
+			Section* sp = sym->section;
+			if ((sp != nullptr) && (sp->flags & Section::sect_CODE)) {
+				int index;
+				TraceDqrProfiler::ADDRESS addr;
+
+				addr = sym->address;
+				index = (addr - sp->startAddr) / 2;
+
+				uint32_t i;
+
+				i = 0;
+
+				do { // do at least one
+					if (sp->fName[index + i] == nullptr) {
+						sp->fName[index + i] = sym->srcFile->name;
+						sp->line[index + i] = 0;
+					}
+					i += 1;
+				} while (i < (uint32_t)sym->size / 2);
+			}
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ElfReader::getInstructionByAddress(TraceDqrProfiler::ADDRESS addr, TraceDqrProfiler::RV_INST& inst)
+{
+	// get instruction at addr
+
+	// Address for code[0] is text->vma
+
+	//don't forget base!!'
+
+	// hmmm.. probably should cache section pointer, and not address/instruction! Or maybe not cache anything?
+
+	Section* sp;
+	if (codeSectionLst == nullptr) {
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	sp = codeSectionLst->getSectionByAddress(addr);
+	if (sp == nullptr) {
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	if ((addr < sp->startAddr) || (addr > sp->endAddr)) {
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	//	if ((addr < text->vma) || (addr >= text->vma + text->size)) {
+	////			don't know instruction - not part of text segment. need to handle for os
+	////			if we can't get the instruciton, get the next trace message and try again. or do
+	////			we need the next sync message and the next trace message and try again?
+	//
+	//		// for now, just return an error
+	//
+	//		status = dqr::DQERR_ERR;
+	//		return status;
+	//	}
+
+	int index;
+
+	index = (addr - sp->startAddr) / 2;
+
+	inst = sp->code[index];
+
+	// if 32 bit instruction, get the second half
+
+	switch (inst & 0x0003) {
+	case 0x0000:	// quadrant 0, compressed
+	case 0x0001:	// quadrant 1, compressed
+	case 0x0002:	// quadrant 2, compressed
+		status = TraceDqrProfiler::DQERR_OK;
+		break;
+	case 0x0003:	// not compressed. Assume RV32 for now
+		if ((inst & 0x1f) == 0x1f) {
+			fprintf(stderr, "Error: getInstructionByAddress(): cann't decode instructions longer than 32 bits\n");
+			status = TraceDqrProfiler::DQERR_ERR;
+			break;
+		}
+
+		inst = inst | (((uint32_t)sp->code[index + 1]) << 16);
+
+		status = TraceDqrProfiler::DQERR_OK;
+		break;
+	}
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr ElfReader::parseNLSStrings(TraceDqrProfiler::nlStrings* nlsStrings)
+{
+	Section* sp;
+	bool found = false;
+	int rc;
+
+	for (sp = codeSectionLst; (sp != NULL) && !found;) {
+		if (strcmp(sp->name,".comment") == 0) {
+			found = true;
+		}
+		else {
+			sp = sp->next;
+		}
+	}
+
+	if (!found) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	int size = sp->size;
+	char* data;
+
+	data = new (std::nothrow) char[size];
+
+	if (data == nullptr) {
+		printf("Error: elfReader::parseNLSStrings(): Could not allocate data array\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	int fd;
+	fd = _open(elfName, O_RDONLY);
+	if (fd < 0) {
+		printf("Error: elfReader::parseNLSStrings(): Could not open file %s for input\n", elfName);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	rc = lseek(fd, sp->offset, SEEK_SET);
+	if (rc < 0) {
+		printf("Error: ElfReder::parseNLSStrings(): Error seeking to .comment section");
+		_close(fd);
+		fd = -1;
+		delete[] data;
+		data = nullptr;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	rc = _read(fd, data, size);
+	if (rc != size) {
+		printf("Error: ElfReader::parseNLSStrings(): Error reading .comment section\n");
+		_close(fd);
+		fd = -1;
+		delete[] data;
+		data = nullptr;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	_close(fd);
+	fd = -1;
+
+	int index;
+
+	for (int i = 0; i < 32; i++) {
+		nlsStrings[i].nf = 0;
+		nlsStrings[i].signedMask = 0;
+		nlsStrings[i].format = nullptr;
+	}
+
+	for (int i = 0; i < size;) {
+		char* end;
+
+		index = strtol(&data[i], &end, 0);
+
+		if (end != &data[i]) {
+			// found an index
+
+			i = end - data;
+
+			if ((index >= 32) || (index < 0) || (data[i] != ':')) {
+				// invalid format string - skip
+				while ((i < size) && (data[i] != 0)) {
+					i += 1;
+				}
+				i += 1;
+			}
+			else {
+				// found a format string
+
+				// need to find end of string
+				int e;
+				int nf = 0;
+				int state = 0;
+
+				for (e = i + 1; (data[e] != 0) && (e < size); e++) {
+					// need to figure out if %s are signed or unsigned
+
+					switch (state) {
+					case 0:
+						if (data[e] == '%') {
+							state = 1;
+						}
+						break;
+					case 1: // found a %, figure out format
+						switch (data[e]) {
+						case '%':
+							state = 0;
+							break;
+							// signed cases
+						case 'd':
+						case 'i':
+							nlsStrings[index].signedMask |= (1 << nf);
+							nf += 1;
+							state = 0;
+							break;
+							// unsigned cases
+						case 'o':
+						case 'u':
+						case 'x':
+						case 'X':
+						case 'e':
+						case 'E':
+						case 'f':
+						case 'F':
+						case 'g':
+						case 'G':
+						case 'a':
+						case 'A':
+						case 'c':
+						case 's':
+						case 'p':
+						case 'n':
+						case 'M':
+							state = 0;
+							nf += 1;
+							break;
+						default:
+							break;
+						}
+					}
+				}
+
+				if (data[e] != 0) {
+					// invalid format string - not null terminated
+
+					//should we delete here?
+
+					for (int i = 0; i < 32; i++) {
+						if (nlsStrings[i].format != nullptr) {
+							delete[] nlsStrings[i].format;
+							nlsStrings[i].format = nullptr;
+						}
+					}
+
+					// don't delete nlsStrings here! We didn't allocate it!
+
+					delete[] data;
+					data = nullptr;
+
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				nlsStrings[index].nf = nf;
+				nlsStrings[index].format = new char[e - i + 1];
+
+				strcpy(nlsStrings[index].format, &data[i + 1]);
+
+				i = e + 1;
+			}
+		}
+		else {
+			// skip string, look for another
+			while ((i < size) && (data[i] != 0)) {
+				i += 1;
+			}
+			i += 1;
+		}
+	}
+
+	//	for (int i = 0; i < 32; i++) {
+	//		printf("nlsStrings[%d]: %d  %02x %s\n",i,nlsStrings[i].nf,nlsStrings[i].signedMask,nlsStrings[i].format);
+	//	}
+
+	delete[] data;
+	data = nullptr;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+Symtab* ElfReader::getSymtab()
+{
+	return symtab;
+}
+
+TraceDqrProfiler::DQErr ElfReader::dumpSyms()
+{
+	if (symtab == nullptr) {
+		symtab = getSymtab();
+	}
+
+	symtab->dump();
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TsList::TsList()
+{
+	prev = nullptr;
+	next = nullptr;
+	message = nullptr;
+	terminated = false;
+
+	startTime = (TraceDqrProfiler::TIMESTAMP)0;
+	endTime = (TraceDqrProfiler::TIMESTAMP)0;
+}
+
+TsList::~TsList()
+{
+}
+
+ITCPrint::ITCPrint(int itcPrintOpts, int numCores, int buffSize, int channel, TraceDqrProfiler::nlStrings* nlsStrings)
+{
+	if ((numCores <= 0) || (buffSize <= 0)) {
+		printf("Error: ITCPrint::ITCPrint(): Bad numCores or bufSize argument\n");
+
+		// just make some defaults and fly from there
+
+		numCores = 1;
+		buffSize = 1024;
+	}
+
+	this->numCores = numCores;
+	this->buffSize = buffSize;
+	this->printChannel = channel;
+	this->nlsStrings = nlsStrings;
+
+	itcOptFlags = itcPrintOpts;
+
+	pbuff = new char* [numCores];
+
+	for (int i = 0; i < numCores; i++) {
+		pbuff[i] = new char[buffSize];
+	}
+
+	numMsgs = new int[numCores];
+
+	for (int i = 0; i < numCores; i++) {
+		numMsgs[i] = 0;
+	}
+
+	pbi = new int[numCores];
+
+	for (int i = 0; i < numCores; i++) {
+		pbi[i] = 0;
+	}
+
+	pbo = new int[numCores];
+
+	for (int i = 0; i < numCores; i++) {
+		pbo[i] = 0;
+	}
+
+	freeList = nullptr;
+
+	tsList = new TsList * [numCores];
+
+	for (int i = 0; i < numCores; i++) {
+		tsList[i] = nullptr;
+	}
+}
+
+ITCPrint::~ITCPrint()
+{
+	nlsStrings = nullptr; // don't delete this here - it is part of the trace object
+
+	if (pbuff != nullptr) {
+		for (int i = 0; i < numCores; i++) {
+			if (pbuff[i] != nullptr) {
+				delete[] pbuff[i];
+				pbuff[i] = nullptr;
+			}
+		}
+
+		delete[] pbuff;
+		pbuff = nullptr;
+	}
+
+	if (numMsgs != nullptr) {
+		delete[] numMsgs;
+		numMsgs = nullptr;
+	}
+
+	if (pbi != nullptr) {
+		delete[] pbi;
+		pbi = nullptr;
+	}
+
+	if (pbo != nullptr) {
+		delete[] pbo;
+		pbo = nullptr;
+	}
+
+	if (freeList != nullptr) {
+		TsList* tl = freeList;
+		while (tl != nullptr) {
+			TsList* tln = tl->next;
+			delete tl;
+			tl = tln;
+		}
+		freeList = nullptr;
+	}
+
+	if (tsList != nullptr) {
+		for (int i = 0; i < numCores; i++) {
+			TsList* tl = tsList[i];
+			if (tl != nullptr) {
+				do {
+					TsList* tln = tl->next;
+					delete tl;
+					tl = tln;
+				} while ((tl != tsList[i]) && (tl != nullptr));
+			}
+		}
+		delete[] tsList;
+		tsList = nullptr;
+	}
+}
+
+int ITCPrint::roomInITCPrintQ(uint8_t core)
+{
+	if (core >= numCores) {
+		return 0;
+	}
+
+	if (pbi[core] > pbo[core]) {
+		return buffSize - pbi[core] + pbo[core] - 1;
+	}
+
+	if (pbi[core] < pbo[core]) {
+		return pbo[core] - pbi[core] - 1;
+	}
+
+	return buffSize - 1;
+}
+
+bool ITCPrint::print(uint8_t core, uint32_t addr, uint32_t data, TraceDqrProfiler::TIMESTAMP tstamp)
+{
+	if (core >= numCores) {
+		return false;
+	}
+
+	//	here we want to process nls!!!
+	//	check is addr has an itc print format string (in nlsStrings)
+
+	TsList* tlp;
+	tlp = tsList[core];
+	TsList* workingtlp;
+	int channel;
+
+	channel = addr / 4;
+
+	if (itcOptFlags & TraceDqrProfiler::ITC_OPT_NLS) {
+		if (((addr & 0x03) == 0) && (nlsStrings != nullptr) && (nlsStrings[channel].format != nullptr)) {
+			int args[4];
+			char dst[256];
+			int dstLen = 0;
+
+			// have a no-load-string print
+
+			// need to get args for print
+
+			switch (nlsStrings[channel].nf) {
+			case 0:
+				dstLen = sprintf(dst, nlsStrings[channel].format);
+				break;
+			case 1:
+				dstLen = sprintf(dst, nlsStrings[channel].format, data);
+				break;
+			case 2:
+				for (int i = 0; i < 2; i++) {
+					if (nlsStrings[channel].signedMask & (1 << i)) {
+						// signed
+						args[i] = (int16_t)(data >> ((1 - i) * 16));
+					}
+					else {
+						// unsigned
+						args[i] = (uint16_t)(data >> ((1 - i) * 16));
+					}
+				}
+				dstLen = sprintf(dst, nlsStrings[channel].format, args[0], args[1]);
+				break;
+			case 3:
+				args[0] = (data >> (32 - 11)) & 0x7ff; // 10 bit
+				args[1] = (data >> (32 - 22)) & 0x7ff; // 11 bit
+				args[2] = (data >> (32 - 32)) & 0x3ff; // 11 bit
+
+				if (nlsStrings[channel].signedMask & (1 << 0)) {
+					if (args[0] & 0x400) {
+						args[0] |= 0xfffff800;
+					}
+				}
+
+				if (nlsStrings[channel].signedMask & (1 << 1)) {
+					if (args[1] & 0x400) {
+						args[1] |= 0xfffff800;
+					}
+				}
+
+				if (nlsStrings[channel].signedMask & (1 << 2)) {
+					if (args[2] & 0x200) {
+						args[2] |= 0xfffffc00;
+					}
+				}
+
+				dstLen = sprintf(dst, nlsStrings[channel].format, args[0], args[1], args[2]);
+				break;
+			case 4:
+				for (int i = 0; i < 4; i++) {
+					if (nlsStrings[channel].signedMask & (1 << i)) {
+						// signed
+						args[i] = (int8_t)(data >> ((3 - i) * 8));
+					}
+					else {
+						// unsigned
+						args[i] = (uint8_t)(data >> ((3 - i) * 8));
+					}
+				}
+				dstLen = sprintf(dst, nlsStrings[channel].format, args[0], args[1], args[2], args[3]);
+				break;
+			default:
+				dstLen = sprintf(dst, "Error: invalid number of args for format string %d, %s", channel, nlsStrings[channel].format);
+				break;
+			}
+
+			if ((tsList[core] != nullptr) && (tsList[core]->terminated == false)) {
+				// terminate the current message
+
+				pbuff[core][pbi[core]] = 0;	// add a null termination after the eol
+				pbi[core] += 1;
+
+				if (pbi[core] >= buffSize) {
+					pbi[core] = 0;
+				}
+
+				numMsgs[core] += 1;
+
+				tsList[core]->terminated = true;
+			}
+
+			// check free list for available struct
+
+			if (freeList != nullptr) {
+				workingtlp = freeList;
+				freeList = workingtlp->next;
+
+				workingtlp->terminated = false;
+				workingtlp->message = nullptr;
+			}
+			else {
+				workingtlp = new TsList();
+			}
+
+			if (tlp == nullptr) {
+				workingtlp->next = workingtlp;
+				workingtlp->prev = workingtlp;
+			}
+			else {
+				workingtlp->next = tlp;
+				workingtlp->prev = tlp->prev;
+
+				tlp->prev = workingtlp;
+				workingtlp->prev->next = workingtlp;
+			}
+
+			workingtlp->startTime = tstamp;
+			workingtlp->endTime = tstamp;
+			workingtlp->message = &pbuff[core][pbi[core]];
+
+			tsList[core] = workingtlp;
+
+			// workingtlp now points to unterminated TSList object
+
+			int room = roomInITCPrintQ(core);
+
+			for (int i = 0; i < dstLen; i++) {
+				if (room >= 2) { // 2 because we need to make sure there is room for the nul termination
+					pbuff[core][pbi[core]] = dst[i];
+					pbi[core] += 1;
+					if (pbi[core] >= buffSize) {
+						pbi[core] = 0;
+					}
+					room -= 1;
+				}
+			}
+
+			pbuff[core][pbi[core]] = 0;
+			pbi[core] += 1;
+			if (pbi[core] >= buffSize) {
+				pbi[core] = 0;
+			}
+
+			workingtlp->terminated = true;
+			numMsgs[core] += 1;
+
+			return true;
+		}
+	}
+
+	if (itcOptFlags & TraceDqrProfiler::ITC_OPT_PRINT) {
+		if ((addr < (uint32_t)printChannel * 4) || (addr >= (((uint32_t)printChannel + 1) * 4))) {
+			// not writing to this itc channel
+
+			return false;
+		}
+
+		if ((tlp == nullptr) || tlp->terminated == true) {
+			// see if there is one on the free list before making a new one
+
+			if (freeList != nullptr) {
+				workingtlp = freeList;
+				freeList = workingtlp->next;
+
+				workingtlp->terminated = false;
+				workingtlp->message = nullptr;
+			}
+			else {
+				workingtlp = new TsList();
+			}
+
+			if (tlp == nullptr) {
+				workingtlp->next = workingtlp;
+				workingtlp->prev = workingtlp;
+			}
+			else {
+				workingtlp->next = tlp;
+				workingtlp->prev = tlp->prev;
+
+				tlp->prev = workingtlp;
+				workingtlp->prev->next = workingtlp;
+			}
+
+			workingtlp->terminated = false;
+			workingtlp->startTime = tstamp;
+			workingtlp->message = &pbuff[core][pbi[core]];
+
+			tsList[core] = workingtlp;
+		}
+		else {
+			workingtlp = tlp;
+		}
+
+		// workingtlp now points to unterminated TSList object (in progress)
+
+		workingtlp->endTime = tstamp;
+
+		char* p = (char*)&data;
+		int room = roomInITCPrintQ(core);
+
+		for (int i = 0; ((size_t)i < ((sizeof data) - (addr & 0x03))); i++) {
+			if (room >= 2) {
+				pbuff[core][pbi[core]] = p[i];
+				pbi[core] += 1;
+				if (pbi[core] >= buffSize) {
+					pbi[core] = 0;
+				}
+				room -= 1;
+
+				switch (p[i]) {
+				case 0:
+					numMsgs[core] += 1;
+
+					workingtlp->terminated = true;
+					break;
+				case '\n':
+				case '\r':
+					pbuff[core][pbi[core]] = 0;	// add a null termination after the eol
+					pbi[core] += 1;
+					if (pbi[core] >= buffSize) {
+						pbi[core] = 0;
+					}
+					room -= 1;
+					numMsgs[core] += 1;
+
+					workingtlp->terminated = true;
+					break;
+				default:
+					break;
+				}
+			}
+		}
+
+		pbuff[core][pbi[core]] = 0; // make sure always null terminated. This may be a temporary null termination
+
+		// returning true means it was an itc print msg and has been processed
+		// false means it was not, and should be handled normally
+
+		return true;
+	}
+
+	return false;
+}
+
+bool ITCPrint::haveITCPrintMsgs()
+{
+	for (int core = 0; core < numCores; core++) {
+		if (numMsgs[core] != 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int ITCPrint::getITCPrintMask()
+{
+	int mask = 0;
+
+	for (int core = 0; core < numCores; core++) {
+		if (numMsgs[core] != 0) {
+			mask |= 1 << core;
+		}
+	}
+
+	return mask;
+}
+
+int ITCPrint::getITCFlushMask()
+{
+	int mask = 0;
+
+	for (int core = 0; core < numCores; core++) {
+		if (numMsgs[core] > 0) {
+			mask |= 1 << core;
+		}
+		else if (pbo[core] != pbi[core]) {
+			mask |= 1 << core;
+		}
+	}
+
+	return mask;
+}
+
+void ITCPrint::haveITCPrintData(int numMsgs[], bool havePrintData[])
+{
+	if (numMsgs != nullptr) {
+		for (int i = 0; i < numCores; i++) {
+			numMsgs[i] = this->numMsgs[i];
+		}
+	}
+
+	if (havePrintData != nullptr) {
+		for (int i = 0; i < numCores; i++) {
+			havePrintData[i] = pbi[i] != pbo[i];
+		}
+	}
+}
+
+TsList* ITCPrint::consumeTerminatedTsList(int core)
+{
+	TsList* rv = nullptr;
+
+	if (numMsgs[core] > 0) { // have stuff in the Q
+		TsList* tsl = tsList[core];
+
+		// tsl now points to the newest tslist object. We want the oldest, which will be tsl->prev
+
+		if (tsl != nullptr) {
+			tsl = tsl->prev;
+
+			if (tsl->terminated == true) {
+				rv = tsl;
+
+				// unlink tsl (consume it)
+
+				if (tsl->next == tsl) {
+					// was the only one in list
+
+					tsList[core] = nullptr;
+				}
+				else {
+					tsList[core]->prev = tsl->prev;
+
+					if (tsList[core]->next == tsl) {
+						tsList[core]->next = tsl->next;
+					}
+				}
+
+				tsl->next = freeList;
+				tsl->prev = nullptr;
+				freeList = tsl;
+			}
+		}
+	}
+
+	return rv;
+}
+
+TsList* ITCPrint::consumeOldestTsList(int core)
+{
+	TsList* rv;
+
+	rv = consumeTerminatedTsList(core);
+	if (rv == nullptr) {
+		// no terminated itc prints. Look for one in progress
+
+		TsList* tsl = tsList[core];
+
+		if (tsl != nullptr) {
+			// this must be an unterminated tsl. unlink tsl (consume it)
+
+			rv = tsl;
+
+			if (tsl->next == tsl) {
+				// was the only one in the list!
+
+				tsList[core] = nullptr;
+			}
+			else {
+				tsList[core]->prev = tsl->prev;
+
+				if (tsList[core]->next == tsl) {
+					tsList[core]->next = tsl->next;
+				}
+			}
+
+			tsl->next = freeList;
+			tsl->prev = nullptr;
+			freeList = tsl;
+		}
+	}
+
+	return rv;
+}
+
+bool ITCPrint::getITCPrintMsg(uint8_t core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	bool rc = false;
+
+	if (core >= numCores) {
+		return false;
+	}
+
+	if ((dst == nullptr) || (dstLen <= 0)) {
+		printf("Error: ITCPrint::getITCPrintMsg(): Bad dst argument or size\n");
+
+		return false;
+	}
+
+	if (numMsgs[core] > 0) {
+		TsList* tsl = consumeTerminatedTsList(core);
+
+		if (tsl != nullptr) {
+			startTime = tsl->startTime;
+			endTime = tsl->endTime;
+		}
+		else if (tsl == nullptr) {
+			printf("Error: ITCPrint::getITCPrintMsg(): tsl is null\n");
+			return false;
+		}
+
+		rc = true;
+		numMsgs[core] -= 1;
+
+		while (pbuff[core][pbo[core]] && (dstLen > 1)) {
+			*dst++ = pbuff[core][pbo[core]];
+			dstLen -= 1;
+
+			pbo[core] += 1;
+			if (pbo[core] >= buffSize) {
+				pbo[core] = 0;
+			}
+		}
+
+		*dst = 0;
+
+		// skip past null terminted end of message
+
+		pbo[core] += 1;
+		if (pbo[core] >= buffSize) {
+			pbo[core] = 0;
+		}
+	}
+
+	return rc;
+}
+
+bool ITCPrint::flushITCPrintMsg(uint8_t core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	if (core >= numCores) {
+		printf("Error: ITCPrint::flushITCPringMsg(): Core out of range (%d)\n", core);
+		return false;
+	}
+
+	if ((dst == nullptr) || (dstLen <= 0)) {
+		printf("Error: ITCPrint::flushITCPrintMsg(): Bad dst argument\n");
+		return false;
+	}
+
+	if (numMsgs[core] > 0) {
+		return getITCPrintMsg(core, dst, dstLen, startTime, endTime);
+	}
+
+	if (pbo[core] != pbi[core]) {
+		TsList* tsl = consumeOldestTsList(core);
+
+		if ((tsl == nullptr) || (tsl->terminated != false)) {
+			printf("Error: ITCPrint::flushITCPrintMsg(): bad tsl object\n");
+			return false;
+		}
+
+		startTime = tsl->startTime;
+		endTime = tsl->endTime;
+
+		while (pbuff[core][pbo[core]] && (dstLen > 1)) {
+			*dst++ = pbuff[core][pbo[core]];
+			dstLen -= 1;
+
+			pbo[core] += 1;
+			if (pbo[core] >= buffSize) {
+				pbo[core] = 0;
+			}
+		}
+		return true;
+	}
+
+	return false;
+}
+
+bool ITCPrint::getITCPrintStr(uint8_t core, std::string& s, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	if (core >= numCores) {
+		return false;
+	}
+
+	bool rc = false;
+
+	if (numMsgs[core] > 0) { // stuff in the Q
+		rc = true;
+
+		TsList* tsl = consumeTerminatedTsList(core);
+
+		if (tsl == nullptr) {
+			printf("Error: ITCPrint::getITCPrintStr(): Bad tsl pointer\n");
+			return false;
+		}
+
+		startTime = tsl->startTime;
+		endTime = tsl->endTime;
+
+		numMsgs[core] -= 1;
+
+		while (pbuff[core][pbo[core]]) {
+			s += pbuff[core][pbo[core]];
+
+			pbo[core] += 1;
+			if (pbo[core] >= buffSize) {
+				pbo[core] = 0;
+			}
+		}
+
+		pbo[core] += 1;
+		if (pbo[core] >= buffSize) {
+			pbo[core] = 0;
+		}
+	}
+
+	return rc;
+}
+
+bool ITCPrint::flushITCPrintStr(uint8_t core, std::string& s, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	if (core >= numCores) {
+		return false;
+	}
+
+	if (numMsgs[core] > 0) {
+		return getITCPrintStr(core, s, startTime, endTime);
+	}
+
+	if (pbo[core] != pbi[core]) {
+		TsList* tsl = consumeOldestTsList(core);
+
+		if ((tsl == nullptr) || (tsl->terminated != false)) {
+			printf("Error: ITCPrint::flushITCPrintStr(): Bad tsl pointer\n");
+			return false;
+		}
+
+		startTime = tsl->startTime;
+		endTime = tsl->endTime;
+
+		s = "";
+		while (pbuff[core][pbo[core]]) {
+			s += pbuff[core][pbo[core]];
+
+			pbo[core] += 1;
+			if (pbo[core] >= buffSize) {
+				pbo[core] = 0;
+			}
+		}
+		return true;
+	}
+
+	return false;
+}
+
+ProfilerAnalytics::ProfilerAnalytics()
+{
+	cores = 0;
+	num_trace_msgs_all_cores = 0;
+	num_trace_bits_all_cores = 0;
+	num_trace_bits_all_cores_max = 0;
+	num_trace_bits_all_cores_min = 0;
+	num_trace_mseo_bits_all_cores = 0;
+
+	num_inst_all_cores = 0;
+	num_inst16_all_cores = 0;
+	num_inst32_all_cores = 0;
+
+	num_branches_all_cores = 0;
+
+	for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+		core[i].num_inst16 = 0;
+		core[i].num_inst32 = 0;
+		core[i].num_inst = 0;
+
+		core[i].num_trace_msgs = 0;
+		core[i].num_trace_syncs = 0;
+		core[i].num_trace_dbranch = 0;
+		core[i].num_trace_ibranch = 0;
+		core[i].num_trace_ihistory = 0;
+		core[i].num_trace_ihistoryws = 0;
+		core[i].num_trace_resourcefull = 0;
+		core[i].num_trace_incircuittraceWS = 0;
+		core[i].num_trace_incircuittrace = 0;
+
+		core[i].num_trace_dataacq = 0;
+		core[i].num_trace_dbranchws = 0;
+		core[i].num_trace_ibranchws = 0;
+		core[i].num_trace_correlation = 0;
+		core[i].num_trace_auxaccesswrite = 0;
+		core[i].num_trace_ownership = 0;
+		core[i].num_trace_error = 0;
+
+		core[i].num_trace_ts = 0;
+		core[i].num_trace_uaddr = 0;
+		core[i].num_trace_faddr = 0;
+		core[i].num_trace_ihistory_taken_branches = 0;
+		core[i].num_trace_ihistory_nottaken_branches = 0;
+		core[i].num_trace_resourcefull_i_cnt = 0;
+		core[i].num_trace_resourcefull_hist = 0;
+		core[i].num_trace_resourcefull_takenCount = 0;
+		core[i].num_trace_resourcefull_notTakenCount = 0;
+		core[i].num_trace_resourcefull_taken_branches = 0;
+		core[i].num_trace_resourcefull_nottaken_branches = 0;
+
+		core[i].trace_bits = 0;
+		core[i].trace_bits_max = 0;
+		core[i].trace_bits_min = 0;
+		core[i].trace_bits_mseo = 0;
+
+		core[i].max_hist_bits = 0;
+		core[i].min_hist_bits = 0;
+		core[i].max_notTakenCount = 0;
+		core[i].min_notTakenCount = 0;
+		core[i].max_takenCount = 0;
+		core[i].min_takenCount = 0;
+
+		core[i].trace_bits_sync = 0;
+		core[i].trace_bits_dbranch = 0;
+		core[i].trace_bits_ibranch = 0;
+		core[i].trace_bits_dataacq = 0;
+		core[i].trace_bits_dbranchws = 0;
+		core[i].trace_bits_ibranchws = 0;
+		core[i].trace_bits_ihistory = 0;
+		core[i].trace_bits_ihistoryws = 0;
+		core[i].trace_bits_resourcefull = 0;
+		core[i].trace_bits_correlation = 0;
+		core[i].trace_bits_auxaccesswrite = 0;
+		core[i].trace_bits_ownership = 0;
+		core[i].trace_bits_error = 0;
+		core[i].trace_bits_incircuittrace = 0;
+		core[i].trace_bits_incircuittraceWS = 0;
+
+		core[i].trace_bits_ts = 0;
+		core[i].trace_bits_ts_max = 0;
+		core[i].trace_bits_ts_min = 0;
+
+		core[i].trace_bits_uaddr = 0;
+		core[i].trace_bits_uaddr_max = 0;
+		core[i].trace_bits_uaddr_min = 0;
+
+		core[i].trace_bits_faddr = 0;
+		core[i].trace_bits_faddr_max = 0;
+		core[i].trace_bits_faddr_min = 0;
+
+		core[i].trace_bits_hist = 0;
+
+		core[i].num_taken_branches = 0;
+		core[i].num_notTaken_branches = 0;
+		core[i].num_calls = 0;
+		core[i].num_returns = 0;
+		core[i].num_swaps = 0;
+		core[i].num_exceptions = 0;
+		core[i].num_exception_returns = 0;
+		core[i].num_interrupts = 0;
+	}
+
+#ifdef DO_TIMES
+	etimer = new Timer();
+#endif // DO_TIMES
+
+	status = TraceDqrProfiler::DQERR_OK;
+}
+
+ProfilerAnalytics::~ProfilerAnalytics()
+{
+#ifdef DO_TIMES
+	if (etimer != nullptr) {
+		delete etimer;
+		etimer = nullptr;
+	}
+#endif // DO_TIMES
+}
+
+TraceDqrProfiler::DQErr ProfilerAnalytics::updateTraceInfo(ProfilerNexusMessage& nm, uint32_t bits, uint32_t mseo_bits, uint32_t ts_bits, uint32_t addr_bits)
+{
+	bool have_uaddr = false;
+	bool have_faddr = false;
+
+	num_trace_msgs_all_cores += 1;
+	num_trace_bits_all_cores += bits;
+	num_trace_mseo_bits_all_cores += mseo_bits;
+
+	core[nm.coreId].num_trace_msgs += 1;
+
+	if (bits > num_trace_bits_all_cores_max) {
+		num_trace_bits_all_cores_max = bits;
+	}
+
+	if ((num_trace_bits_all_cores_min == 0) || (bits < num_trace_bits_all_cores_min)) {
+		num_trace_bits_all_cores_min = bits;
+	}
+
+	core[nm.coreId].trace_bits_mseo += mseo_bits;
+	core[nm.coreId].trace_bits += bits;
+
+	if (bits > core[nm.coreId].trace_bits_max) {
+		core[nm.coreId].trace_bits_max = bits;
+	}
+
+	if ((core[nm.coreId].trace_bits_min == 0) || (bits < core[nm.coreId].trace_bits_min)) {
+		core[nm.coreId].trace_bits_min = bits;
+	}
+
+	cores |= (1 << nm.coreId);
+
+	if (ts_bits > 0) {
+		core[nm.coreId].num_trace_ts += 1;
+		core[nm.coreId].trace_bits_ts += ts_bits;
+
+		if (ts_bits > core[nm.coreId].trace_bits_ts_max) {
+			core[nm.coreId].trace_bits_ts_max = ts_bits;
+		}
+
+		if ((core[nm.coreId].trace_bits_ts_min == 0) || (ts_bits < core[nm.coreId].trace_bits_ts_min)) {
+			core[nm.coreId].trace_bits_ts_min = ts_bits;
+		}
+	}
+
+	int msb;
+	uint64_t mask;
+	int taken;
+	int nottaken;
+
+	switch (nm.tcode) {
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+		core[nm.coreId].num_trace_ownership += 1;
+		core[nm.coreId].trace_bits_ownership += bits;
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+		core[nm.coreId].num_trace_dbranch += 1;
+		core[nm.coreId].trace_bits_dbranch += bits;
+		num_branches_all_cores += 1;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		core[nm.coreId].num_trace_ibranch += 1;
+		core[nm.coreId].trace_bits_ibranch += bits;
+		num_branches_all_cores += 1;
+
+		have_uaddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+		core[nm.coreId].num_trace_dataacq += 1;
+		core[nm.coreId].trace_bits_dataacq += bits;
+		break;
+	case TraceDqrProfiler::TCODE_ERROR:
+		core[nm.coreId].num_trace_error += 1;
+		core[nm.coreId].trace_bits_error += bits;
+		break;
+	case TraceDqrProfiler::TCODE_SYNC:
+		core[nm.coreId].num_trace_syncs += 1;
+		core[nm.coreId].trace_bits_sync += bits;
+
+		have_faddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		core[nm.coreId].num_trace_dbranchws += 1;
+		core[nm.coreId].trace_bits_dbranchws += bits;
+		num_branches_all_cores += 1;
+
+		have_faddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		core[nm.coreId].num_trace_ibranchws += 1;
+		core[nm.coreId].trace_bits_ibranchws += bits;
+		num_branches_all_cores += 1;
+
+		have_faddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+		core[nm.coreId].num_trace_auxaccesswrite += 1;
+		core[nm.coreId].trace_bits_auxaccesswrite += bits;
+		break;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		core[nm.coreId].num_trace_correlation += 1;
+		core[nm.coreId].trace_bits_ibranchws += bits;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		core[nm.coreId].num_trace_ihistory += 1;
+		core[nm.coreId].trace_bits_ihistory += bits;
+
+		// need to find msb = 1
+
+		msb = -1;
+		mask = nm.indirectHistory.history;
+		taken = -1;	// start at -1 to account for stop bit, which isn't a branch
+		nottaken = 0;
+
+		while (mask > 1) { // use > 1 because the most significant 1 is a stop bit which we don't want to count!
+			msb += 1;
+			if (mask & 1) {
+				taken += 1;
+			}
+			else {
+				nottaken += 1;
+			}
+			mask >>= 1;
+		}
+
+		core[nm.coreId].num_trace_ihistory_taken_branches += taken;
+		core[nm.coreId].num_trace_ihistory_nottaken_branches += nottaken;
+
+		if (msb >= 0) {
+			core[nm.coreId].trace_bits_hist += msb + 1;
+
+			if (msb >= (int32_t)core[nm.coreId].max_hist_bits) {
+				core[nm.coreId].max_hist_bits = msb + 1;
+			}
+		}
+
+		if ((msb + 1) < (int32_t)core[nm.coreId].min_hist_bits) {
+			core[nm.coreId].min_hist_bits = msb + 1;
+		}
+
+		num_branches_all_cores += 1 + taken + nottaken;
+
+		have_uaddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		core[nm.coreId].num_trace_ihistoryws += 1;
+		core[nm.coreId].trace_bits_ihistoryws += bits;
+
+		// need to find msb = 1
+
+		msb = -1;
+		mask = nm.indirectHistoryWS.history;
+		taken = -1;	// start at -1 to account for stop bit, which isn't a branch
+		nottaken = 0;
+
+		while (mask > 1) {
+			msb += 1;
+			if (mask & 1) {
+				taken += 1;
+			}
+			else {
+				nottaken += 1;
+			}
+			mask >>= 1;
+		}
+
+		core[nm.coreId].num_trace_ihistory_taken_branches += taken;
+		core[nm.coreId].num_trace_ihistory_nottaken_branches += nottaken;
+
+		if (msb >= 0) {
+			core[nm.coreId].trace_bits_hist += msb + 1;
+
+			if (msb >= (int32_t)core[nm.coreId].max_hist_bits) {
+				core[nm.coreId].max_hist_bits = msb + 1;
+			}
+		}
+
+		if ((msb + 1) < (int32_t)core[nm.coreId].min_hist_bits) {
+			core[nm.coreId].min_hist_bits = msb + 1;
+		}
+
+		num_branches_all_cores += 1 + taken + nottaken;
+
+		have_faddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		core[nm.coreId].num_trace_resourcefull += 1;
+		core[nm.coreId].trace_bits_resourcefull += bits;
+
+		switch (nm.resourceFull.rCode) {
+		case 0:
+			core[nm.coreId].num_trace_resourcefull_i_cnt += 1;
+			break;
+		case 1:
+			core[nm.coreId].num_trace_resourcefull_hist += 1;
+
+			// need to find msb = 1
+
+			msb = -1;
+			mask = nm.resourceFull.history;
+			taken = -1;	// start at -1 to account for stop bit, which isn't a branch
+			nottaken = 0;
+
+			while (mask > 1) {
+				msb += 1;
+				if (mask & 1) {
+					taken += 1;
+				}
+				else {
+					nottaken += 1;
+				}
+				mask >>= 1;
+			}
+
+			core[nm.coreId].num_trace_ihistory_taken_branches += taken;
+			core[nm.coreId].num_trace_ihistory_nottaken_branches += nottaken;
+
+			if (msb >= 0) {
+				core[nm.coreId].trace_bits_hist += msb + 1;
+
+				if (msb >= (int32_t)core[nm.coreId].max_hist_bits) {
+					core[nm.coreId].max_hist_bits = msb + 1;
+				}
+			}
+
+			if ((msb + 1) < (int32_t)core[nm.coreId].min_hist_bits) {
+				core[nm.coreId].min_hist_bits = msb + 1;
+			}
+
+			num_branches_all_cores += taken + nottaken;
+			break;
+		case 8:
+			core[nm.coreId].num_trace_resourcefull_notTakenCount += 1;
+			core[nm.coreId].num_trace_resourcefull_nottaken_branches += nm.resourceFull.notTakenCount;
+
+			// compute avg/max/min not taken count
+
+			if (nm.resourceFull.notTakenCount > (uint32_t)core[nm.coreId].max_notTakenCount) {
+				core[nm.coreId].max_notTakenCount = nm.resourceFull.notTakenCount;
+			}
+
+			if ((core[nm.coreId].min_notTakenCount == 0) || (nm.resourceFull.notTakenCount < (uint32_t)core[nm.coreId].min_notTakenCount)) {
+				core[nm.coreId].min_notTakenCount = nm.resourceFull.notTakenCount;
+			}
+			break;
+		case 9:
+			core[nm.coreId].num_trace_resourcefull_takenCount += 1;
+			core[nm.coreId].num_trace_resourcefull_taken_branches += nm.resourceFull.takenCount;
+
+			// compute avg/max/min taken count
+
+			if (nm.resourceFull.takenCount > (uint32_t)core[nm.coreId].max_takenCount) {
+				core[nm.coreId].max_takenCount = nm.resourceFull.takenCount;
+			}
+
+			if ((core[nm.coreId].min_takenCount == 0) || (nm.resourceFull.takenCount < (uint32_t)core[nm.coreId].min_takenCount)) {
+				core[nm.coreId].min_takenCount = nm.resourceFull.takenCount;
+			}
+			break;
+		default:
+			printf("Error: ProfilerAnalytics::updateTraceInfo(): ResoureFull: unknown RDode: %d\n", nm.resourceFull.rCode);
+			status = TraceDqrProfiler::DQERR_ERR;
+			return status;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		core[nm.coreId].num_trace_incircuittrace += 1;
+		core[nm.coreId].trace_bits_incircuittrace += bits;
+		have_uaddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		core[nm.coreId].num_trace_incircuittraceWS += 1;
+		core[nm.coreId].trace_bits_incircuittraceWS += bits;
+		have_faddr = true;
+		break;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	default:
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	if (have_uaddr) {
+		core[nm.coreId].num_trace_uaddr += 1;
+		core[nm.coreId].trace_bits_uaddr += addr_bits;
+
+		if (addr_bits > core[nm.coreId].trace_bits_uaddr_max) {
+			core[nm.coreId].trace_bits_uaddr_max = addr_bits;
+		}
+
+		if ((core[nm.coreId].trace_bits_uaddr_min == 0) || (addr_bits < core[nm.coreId].trace_bits_uaddr_min)) {
+			core[nm.coreId].trace_bits_uaddr_min = addr_bits;
+		}
+	}
+	else if (have_faddr) {
+		core[nm.coreId].num_trace_faddr += 1;
+		core[nm.coreId].trace_bits_faddr += addr_bits;
+
+		if (addr_bits > core[nm.coreId].trace_bits_faddr_max) {
+			core[nm.coreId].trace_bits_faddr_max = addr_bits;
+		}
+
+		if ((core[nm.coreId].trace_bits_faddr_min == 0) || (addr_bits < core[nm.coreId].trace_bits_faddr_min)) {
+			core[nm.coreId].trace_bits_faddr_min = addr_bits;
+		}
+	}
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr ProfilerAnalytics::updateInstructionInfo(uint32_t core_id, uint32_t inst, int instSize, int crFlags, TraceDqrProfiler::BranchFlags brFlags)
+{
+	num_inst_all_cores += 1;
+	core[core_id].num_inst += 1;
+
+	switch (instSize) {
+	case 16:
+		num_inst16_all_cores += 1;
+		core[core_id].num_inst16 += 1;
+		break;
+	case 32:
+		num_inst32_all_cores += 1;
+		core[core_id].num_inst32 += 1;
+		break;
+	default:
+		status = TraceDqrProfiler::DQERR_ERR;
+	}
+
+	switch (brFlags) {
+	case TraceDqrProfiler::BRFLAG_none:
+	case TraceDqrProfiler::BRFLAG_unknown:
+		break;
+	case TraceDqrProfiler::BRFLAG_taken:
+		core[core_id].num_taken_branches += 1;
+		break;
+	case TraceDqrProfiler::BRFLAG_notTaken:
+		core[core_id].num_notTaken_branches += 1;
+		break;
+	}
+
+	if (crFlags & TraceDqrProfiler::isCall) {
+		core[core_id].num_calls += 1;
+	}
+	if (crFlags & TraceDqrProfiler::isReturn) {
+		core[core_id].num_returns += 1;
+	}
+	if (crFlags & TraceDqrProfiler::isSwap) {
+		core[core_id].num_swaps += 1;
+	}
+	if (crFlags & TraceDqrProfiler::isInterrupt) {
+		core[core_id].num_interrupts += 1;
+	}
+	if (crFlags & TraceDqrProfiler::isException) {
+		core[core_id].num_exceptions += 1;
+	}
+	if (crFlags & TraceDqrProfiler::isExceptionReturn) {
+		core[core_id].num_exception_returns += 1;
+	}
+
+	return status;
+}
+
+static void updateDst(int n, char*& dst, int& dst_len)
+{
+	if (n >= dst_len) {
+		dst += dst_len;
+		dst_len = 0;
+	}
+	else {
+		dst += n;
+		dst_len -= n;
+	}
+}
+
+void ProfilerAnalytics::toText(char* dst, int dst_len, int detailLevel)
+{
+	char tmp_dst[512];
+	int n;
+#ifdef DO_TIMES
+	double etime = etimer->etime();
+#endif // DO_TIMES
+
+	if ((dst == nullptr) || (dst_len < 0)) {
+		printf("Error: Anaylics::toText(): Bad dst pointer\n");
+		return;
+	}
+
+	dst[0] = 0;
+
+	if (detailLevel <= 0) {
+		return;
+	}
+
+	uint32_t have_ts = 0;
+
+	for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+		if (cores & (1 << i)) {
+			if (core[i].num_trace_ts > 0) {
+				have_ts |= (1 << i);
+			}
+		}
+	}
+
+	if (srcBits == 0) {
+		n = snprintf(dst, dst_len, "TraceProfiler ProfilerAnalytics: Single core");
+		updateDst(n, dst, dst_len);
+	}
+	else {
+		n = snprintf(dst, dst_len, "TraceProfiler ProfilerAnalytics: Multi core (src field %d bits)", srcBits);
+		updateDst(n, dst, dst_len);
+	}
+
+	if (have_ts == 0) {
+		n = snprintf(dst, dst_len, "; TraceProfiler messages do not have timestamps\n");
+		updateDst(n, dst, dst_len);
+	}
+	else if (have_ts == cores) {
+		n = snprintf(dst, dst_len, "; TraceProfiler messages have timestamps\n");
+		updateDst(n, dst, dst_len);
+	}
+	else {
+		n = snprintf(dst, dst_len, "; Some trace messages have timestamps\n");
+		updateDst(n, dst, dst_len);
+	}
+
+	if (detailLevel == 1) {
+		n = snprintf(dst, dst_len, "\n");
+		updateDst(n, dst, dst_len);
+
+		n = snprintf(dst, dst_len, "Instructions             Compressed                   RV32\n");
+		updateDst(n, dst, dst_len);
+
+		if (num_inst_all_cores > 0) {
+			n = snprintf(dst, dst_len, "  %10u    %10u (%0.2f%%)    %10u (%0.2f%%)\n", num_inst_all_cores, num_inst16_all_cores, ((float)num_inst16_all_cores) / num_inst_all_cores * 100.0, num_inst32_all_cores, ((float)num_inst32_all_cores) / num_inst_all_cores * 100.0);
+		}
+		else {
+			n = snprintf(dst, dst_len, "          -");
+		}
+		updateDst(n, dst, dst_len);
+
+		n = snprintf(dst, dst_len, "\n");
+		updateDst(n, dst, dst_len);
+
+		n = snprintf(dst, dst_len, "Number of TraceProfiler Msgs      Avg Length    Min Length    Max Length    Total Length\n");
+		updateDst(n, dst, dst_len);
+
+		n = snprintf(dst, dst_len, "          %10u          %6.2f    %10u    %10u      %10u\n", num_trace_msgs_all_cores, ((float)num_trace_bits_all_cores) / num_trace_msgs_all_cores, num_trace_bits_all_cores_min, num_trace_bits_all_cores_max, num_trace_bits_all_cores);
+		updateDst(n, dst, dst_len);
+
+		n = snprintf(dst, dst_len, "\n");
+		updateDst(n, dst, dst_len);
+
+		if (num_inst_all_cores > 0) {
+			n = snprintf(dst, dst_len, "TraceProfiler bits per instruction:     %5.2f\n", ((float)num_trace_bits_all_cores) / num_inst_all_cores);
+		}
+		else {
+			n = snprintf(dst, dst_len, "  --\n");
+		}
+		updateDst(n, dst, dst_len);
+
+		n = snprintf(dst, dst_len, "Instructions per trace message: %5.2f\n", ((float)num_inst_all_cores) / num_trace_msgs_all_cores);
+		updateDst(n, dst, dst_len);
+
+		if (num_branches_all_cores > 0) {
+			n = snprintf(dst, dst_len, "Instructions per taken branch:  %5.2f\n", ((float)num_inst_all_cores) / num_branches_all_cores);
+		}
+		else {
+			n = snprintf(dst, dst_len, "--\n");
+		}
+		updateDst(n, dst, dst_len);
+
+		if (srcBits > 0) {
+			n = snprintf(dst, dst_len, "Src bits %% of message:          %5.2f%%\n", ((float)srcBits * num_trace_msgs_all_cores) / num_trace_bits_all_cores * 100.0);
+			updateDst(n, dst, dst_len);
+		}
+
+		if (have_ts != 0 || 1) {
+			int bits_ts = 0;
+
+			for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+				if (cores & (1 << i)) {
+					bits_ts += core[i].trace_bits_ts;
+				}
+			}
+			n = snprintf(dst, dst_len, "Timestamp bits %% of message:    %5.2f%%\n", ((float)bits_ts) / num_trace_bits_all_cores * 100.0);
+			updateDst(n, dst, dst_len);
+		}
+	}
+	else if (detailLevel > 1) {
+		int position;
+		int tabs[] = { 19 + 21 * 0,19 + 21 * 1,19 + 21 * 2,19 + 21 * 3,19 + 21 * 4,19 + 21 * 5,19 + 21 * 6,19 + 21 * 7,19 + 21 * 8 };
+		uint32_t t1, t2;
+		int ts;
+
+		n = sprintf(tmp_dst, "\n");
+		n += sprintf(tmp_dst + n, "                 ");
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				n += sprintf(tmp_dst + n, "          Core %d", i);
+			}
+		}
+
+		if (srcBits > 0) {
+			n += sprintf(tmp_dst + n, "               Total");
+		}
+
+		n += sprintf(tmp_dst + n, "\n");
+
+		n = snprintf(dst, dst_len, "%s", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Instructions");
+
+		t1 = 0;
+		ts = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_inst);
+				t1 += core[i].num_inst;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  Compressed");
+
+		t2 = 0;
+		ts = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_inst > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_inst16, ((float)core[i].num_inst16) / core[i].num_inst * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_inst16;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  RV32");
+
+		t2 = 0;
+		ts = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_inst > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_inst32, ((float)core[i].num_inst32) / core[i].num_inst * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_inst32;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "TraceProfiler Msgs");
+
+		t1 = 0;
+		ts = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_trace_msgs);
+				t1 += core[i].num_trace_msgs;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += printf(" "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  Sync");
+
+		t2 = 0;
+		ts = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_syncs, ((float)core[i].num_trace_syncs) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_syncs;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  DBranch");
+
+		t2 = 0;
+		ts = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_dbranch, ((float)core[i].num_trace_dbranch) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_dbranch;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  IBranch");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_ibranch, ((float)core[i].num_trace_ibranch) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_ibranch;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  DBranch WS");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_dbranchws, ((float)core[i].num_trace_dbranchws) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_dbranchws;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  IBranch WS");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_ibranchws, ((float)core[i].num_trace_ibranchws) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_ibranchws;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  Data Acq");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_dataacq, ((float)core[i].num_trace_dataacq) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_dataacq;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  Correlation");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_correlation, ((float)core[i].num_trace_correlation) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_correlation;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  Aux Acc Write");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_auxaccesswrite, ((float)core[i].num_trace_auxaccesswrite) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_auxaccesswrite;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  Ownership");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_ownership, ((float)core[i].num_trace_ownership) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_ownership;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  Error");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_error, ((float)core[i].num_trace_error) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_error;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  IHistory");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_ihistory, ((float)core[i].num_trace_ihistory) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_ihistory;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  IHistory WS");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_ihistoryws, ((float)core[i].num_trace_ihistoryws) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_ihistoryws;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  RFull ICNT");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_resourcefull_i_cnt, ((float)core[i].num_trace_resourcefull_i_cnt) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_resourcefull_i_cnt;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  RFull HIST");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_resourcefull_hist, ((float)core[i].num_trace_resourcefull_hist) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_resourcefull_hist;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  RFull Taken");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_resourcefull_takenCount, ((float)core[i].num_trace_resourcefull_takenCount) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_resourcefull_takenCount;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  RFull NTaken");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_resourcefull_notTakenCount, ((float)core[i].num_trace_resourcefull_notTakenCount) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_resourcefull_notTakenCount;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  ICT WS");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_incircuittraceWS, ((float)core[i].num_trace_incircuittraceWS) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_ihistoryws;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  ICT");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", core[i].num_trace_incircuittrace, ((float)core[i].num_trace_incircuittrace) / core[i].num_trace_msgs * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t2 += core[i].num_trace_ihistoryws;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%10u (%0.2f%%)", t2, ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "TraceProfiler Bits Total");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits);
+				t1 += core[i].trace_bits;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		//		printf("\n");
+		//		position = printf("TraceProfiler Bits MSEO");
+		//
+		//		ts = 0;
+		//		t1 = 0;
+		//
+		//		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+		//			if (cores & (1<<i)) {
+		//				while (position < tabs[ts]) { position += printf(" "); }
+		//				position += printf("%10u",core[i].trace_bits_mseo);
+		//				t1 += core[i].trace_bits_mseo;
+		//				ts += 1;
+		//			}
+		//		}
+		//
+		//		if (srcBits > 0) {
+		//			while (position < tabs[ts]) { position += printf(" "); }
+		//			printf("%10u",t1);
+		//		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "TraceProfiler Bits/Inst");
+
+		ts = 0;
+		t1 = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_inst > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f", ((float)core[i].trace_bits) / core[i].num_inst);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t1 += core[i].trace_bits;
+				t2 += core[i].num_inst;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t2 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f", ((float)t1) / t2);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Inst/TraceProfiler Msg");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f", ((float)core[i].num_inst) / core[i].num_trace_msgs);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t1 += core[i].num_trace_msgs;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f", ((float)t2) / t1);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Inst/Taken Branch");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if ((core[i].num_trace_dbranch + core[i].num_trace_ibranch + core[i].num_trace_dbranchws + core[i].num_trace_ibranchws + core[i].num_trace_ihistory_taken_branches + core[i].num_trace_resourcefull_taken_branches) > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f", ((float)core[i].num_inst) / (core[i].num_trace_dbranch + core[i].num_trace_ibranch + core[i].num_trace_dbranchws + core[i].num_trace_ibranchws + core[i].num_trace_ihistory_taken_branches + core[i].num_trace_resourcefull_taken_branches));
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t1 += core[i].num_trace_dbranch + core[i].num_trace_ibranch + core[i].num_trace_dbranchws + core[i].num_trace_ibranchws;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f", ((float)t2) / t1);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Avg Msg Length");
+
+		ts = 0;
+		t1 = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_msgs > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f", ((float)core[i].trace_bits) / core[i].num_trace_msgs);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t1 += core[i].trace_bits;
+				t2 += core[i].num_trace_msgs;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t2 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f", ((float)t1) / t2);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Min Msg Length");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_min);
+				if ((t1 == 0) || (core[i].trace_bits_min < t1)) {
+					t1 = core[i].trace_bits_min;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Max Msg Length");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_max);
+				if (core[i].trace_bits_max > t1) {
+					t1 = core[i].trace_bits_max;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Timestamp Counts");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_trace_ts);
+				t1 += core[i].num_trace_ts;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  TStamp Size Avg");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_ts > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f", ((float)core[i].trace_bits_ts) / core[i].num_trace_ts);
+					t2 += core[i].trace_bits_ts;
+				}
+				else {
+					position += sprintf(tmp_dst + position, "         0");
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f", ((float)t2) / t1);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "         0");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  TStamp Size Min");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_ts_min);
+				if ((t1 == 0) || (t1 > core[i].trace_bits_ts_min)) {
+					t1 = core[i].trace_bits_ts_min;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  TStamp Size Max");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_ts_max);
+				if (core[i].trace_bits_ts_max > t1) {
+					t1 = core[i].trace_bits_ts_max;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Timestamp %% of Msg");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].trace_bits > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f%%", ((float)core[i].trace_bits_ts) / core[i].trace_bits * 100.0);
+				}
+				else {
+					position += sprintf(tmp_dst + position, "          -");
+				}
+				t1 += core[i].trace_bits;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f%%", ((float)t2) / t1 * 100.0);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "          -");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "UADDR Counts");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_trace_uaddr);
+				t1 += core[i].num_trace_uaddr;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  UADDR Size Avg");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_uaddr > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f", ((float)core[i].trace_bits_uaddr) / core[i].num_trace_uaddr);
+					t2 += core[i].trace_bits_uaddr;
+				}
+				else {
+					position += sprintf(tmp_dst + position, "        0");
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f", ((float)t2) / t1);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "        0");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  UADDR Size Min");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_uaddr_min);
+				if ((t1 == 0) || (core[i].trace_bits_uaddr_min < t1)) {
+					t1 = core[i].trace_bits_uaddr_min;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  UADDR Size Max");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_uaddr_max);
+				if (t1 < core[i].trace_bits_uaddr_max) {
+					t1 = core[i].trace_bits_uaddr_max;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "FADDR Counts");
+
+		ts = 0;
+		t1 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_trace_faddr);
+				t1 += core[i].num_trace_faddr;
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t1);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  FADDR Size Avg");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				if (core[i].num_trace_faddr > 0) {
+					position += sprintf(tmp_dst + position, "%13.2f", ((float)core[i].trace_bits_faddr) / core[i].num_trace_faddr);
+					t2 = core[i].trace_bits_faddr;
+				}
+				else {
+					position += sprintf(tmp_dst + position, "        0");
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			if (t1 > 0) {
+				position += sprintf(tmp_dst + position, "%13.2f", ((float)t2) / t1);
+			}
+			else {
+				position += sprintf(tmp_dst + position, "        0");
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  FADDR Size Min");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_faddr_min);
+				if ((t2 == 0) || (core[i].trace_bits_faddr_min < t2)) {
+					t2 = core[i].trace_bits_faddr_min;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t2);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "  FADDR Size Max");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].trace_bits_faddr_max);
+				if (core[i].trace_bits_faddr_max > t2) {
+					t2 = core[i].trace_bits_faddr_max;
+				}
+				ts += 1;
+			}
+		}
+
+		if (srcBits > 0) {
+			while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+			position += sprintf(tmp_dst + position, "%10u", t2);
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Taken Branches");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_taken_branches);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Not Taken Branches");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_notTaken_branches);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Calls");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_calls);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Returns");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_returns);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Swaps");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_swaps);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Exceptions");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_exceptions);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Exception Returns");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_exception_returns);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+
+		position = sprintf(tmp_dst, "Interrupts");
+
+		ts = 0;
+		t2 = 0;
+
+		for (int i = 0; i < DQR_PROFILER_MAXCORES; i++) {
+			if (cores & (1 << i)) {
+				while (position < tabs[ts]) { position += sprintf(tmp_dst + position, " "); }
+				position += sprintf(tmp_dst + position, "%10u", core[i].num_interrupts);
+				ts += 1;
+			}
+		}
+
+		n = snprintf(dst, dst_len, "%s\n", tmp_dst);
+		updateDst(n, dst, dst_len);
+	}
+
+#ifdef DO_TIMES
+	n = snprintf(dst, dst_len, "\nTime %f seconds\n", etime);
+	updateDst(n, dst, dst_len);
+	n = snprintf(dst, dst_len, "Instructions decoded per second: %0.2f\n", num_inst_all_cores / etime);
+	updateDst(n, dst, dst_len);
+	n = snprintf(dst, dst_len, "TraceProfiler messages decoded per second: %0.2f\n", num_trace_msgs_all_cores / etime);
+	updateDst(n, dst, dst_len);
+#endif // DO_TIMES
+}
+
+std::string ProfilerAnalytics::toString(int detailLevel)
+{
+	char dst[4096];
+
+	dst[0] = 0;
+
+	toText(dst, sizeof dst, detailLevel);
+
+	return std::string(dst);
+}
+
+uint32_t ProfilerNexusMessage::targetFrequency = 0;
+
+ProfilerNexusMessage::ProfilerNexusMessage()
+{
+	msgNum = 0;
+	tcode = TraceDqrProfiler::TCODE_UNDEFINED;
+	coreId = 0;
+	haveTimestamp = false;
+	timestamp = 0;
+	currentAddress = 0;
+	time = 0;
+	offset = 0;
+	for (int i = 0; (size_t)i < sizeof rawData / sizeof rawData[0]; i++) {
+		rawData[i] = 0xff;
+	}
+}
+
+int ProfilerNexusMessage::getI_Cnt()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+		return directBranch.i_cnt;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		return indirectBranch.i_cnt;
+	case TraceDqrProfiler::TCODE_SYNC:
+		return sync.i_cnt;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		return directBranchWS.i_cnt;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		return indirectBranchWS.i_cnt;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		return correlation.i_cnt;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		return indirectHistory.i_cnt;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		return indirectHistoryWS.i_cnt;
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		if (resourceFull.rCode == 0) {
+			return resourceFull.i_cnt;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+TraceDqrProfiler::ADDRESS ProfilerNexusMessage::getU_Addr()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		return indirectBranch.u_addr;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		return indirectHistory.u_addr;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		switch (ict.cksrc) {
+		case TraceDqrProfiler::ICT_EXT_TRIG:
+			// ckdata0 is the address of the instruciton that retired before generating the exception
+			return ict.ckdata[0];
+		case TraceDqrProfiler::ICT_CONTROL:
+			if (ict.ckdf == 1) {
+				return ict.ckdata[0];
+			}
+			break;
+		case TraceDqrProfiler::ICT_INFERABLECALL:
+			if (ict.ckdf == 0) { // inferrable call
+				// ckdata[0] is the address of the call instruction. destination determined form program image
+				return ict.ckdata[0];
+			}
+			else if (ict.ckdf == 1) { // call/return
+				// ckdata[0] is the address of the call instruction. destination is computed from ckdata[1]
+				return ict.ckdata[0];
+			}
+			break;
+		case TraceDqrProfiler::ICT_EXCEPTION:
+			// ckdata0 the address of the next mainline instruction to execute (will execute after the return from except)
+			return ict.ckdata[0];
+		case TraceDqrProfiler::ICT_INTERRUPT:
+			// ckdata0 is the address of the next instruction to execute in mainline code (will execute after the return from interrupt)
+			return ict.ckdata[0];
+		case TraceDqrProfiler::ICT_CONTEXT:
+			// ckdata[0] is the address of the instruction prior to doing the context switch
+			return ict.ckdata[0];
+		case TraceDqrProfiler::ICT_WATCHPOINT:
+			// ckdata0 is the address of the last instruction to retire??
+			return ict.ckdata[0];
+		case TraceDqrProfiler::ICT_PC_SAMPLE:
+			// periodic pc sample. Address of last instruciton to retire??
+			return ict.ckdata[0];
+		case TraceDqrProfiler::ICT_NONE:
+		default:
+			break;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+	default:
+		break;
+	}
+
+	return -1;
+}
+
+TraceDqrProfiler::ADDRESS ProfilerNexusMessage::getF_Addr()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		return directBranchWS.f_addr;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		return indirectBranchWS.f_addr;
+	case TraceDqrProfiler::TCODE_SYNC:
+		return sync.f_addr;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		return indirectHistoryWS.f_addr;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		switch (ictWS.cksrc) {
+		case TraceDqrProfiler::ICT_EXT_TRIG:
+			// ckdata0 is the address of the instruciton that retired before generating the exception
+			return ictWS.ckdata[0];
+		case TraceDqrProfiler::ICT_CONTROL:
+			if (ictWS.ckdf == 1) {
+				return ictWS.ckdata[0];
+			}
+			break;
+		case TraceDqrProfiler::ICT_INFERABLECALL:
+			if (ictWS.ckdf == 0) { // inferrable call
+				// ckdata[0] is the address of the call instruction. destination determined form program image
+				return ictWS.ckdata[0];
+			}
+			else if (ictWS.ckdf == 1) { // call/return
+				// ckdata[0] is the address of the call instruction. destination is computed from ckdata[1]
+				// for now, just return the faddr
+				return ictWS.ckdata[0];
+			}
+			break;
+		case TraceDqrProfiler::ICT_EXCEPTION:
+			// ckdata0 the address of the next mainline instruction to execute (will execute after the return from except)
+			return ictWS.ckdata[0];
+		case TraceDqrProfiler::ICT_INTERRUPT:
+			// ckdata0 is the address of the next instruction to execute in mainline code (will execute after the return from interrupt)
+			return ictWS.ckdata[0];
+		case TraceDqrProfiler::ICT_CONTEXT:
+			// ckdata[0] is the address of the instruction prior to doing the context switch
+			return ictWS.ckdata[0];
+		case TraceDqrProfiler::ICT_WATCHPOINT:
+			// ckdata0 is the address of the last instruction to retire??
+			return ictWS.ckdata[0];
+		case TraceDqrProfiler::ICT_PC_SAMPLE:
+			// periodic pc sample. Address of last instruciton to retire??
+			return ictWS.ckdata[0];
+		case TraceDqrProfiler::ICT_NONE:
+		default:
+			break;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return -1;
+}
+
+//TraceDqrProfiler::ADDRESS ProfilerNexusMessage::getNextAddr()
+//{
+//	TraceDqrProfiler::ADDRESS addr;
+//
+//	addr = getF_Addr();
+//	if (addr != (TraceDqrProfiler::ADDRESS)-1) {
+//		addr = addr << 1;
+//	}
+//
+//	return addr;
+//}
+
+// Note: for this function to return the correct target address, processTraceMessage() must have already
+// been called for this messages if it is a TCODE_INCIRCUITTRACE message. If it is a TCODE_INCIRCUIRCIUTTRACE_WS,
+// it will work either way
+
+TraceDqrProfiler::ADDRESS    ProfilerNexusMessage::getICTCallReturnTarget()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		if (ict.cksrc == TraceDqrProfiler::ICT_INFERABLECALL) {
+			if (ict.ckdf == 0) {
+				return ict.ckdata[1];
+			}
+			else {
+				return currentAddress ^ (ict.ckdata[1] << 1);
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		if (ictWS.cksrc == TraceDqrProfiler::ICT_INFERABLECALL) {
+			if (ictWS.ckdf == 0) {
+				return ictWS.ckdata[1];
+			}
+			else {
+				return currentAddress ^ (ict.ckdata[1] << 1);
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return -1;
+}
+
+TraceDqrProfiler::BType ProfilerNexusMessage::getB_Type()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		return indirectBranch.b_type;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		return indirectBranchWS.b_type;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		return indirectHistory.b_type;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		return indirectHistoryWS.b_type;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return TraceDqrProfiler::BTYPE_UNDEFINED;
+}
+
+TraceDqrProfiler::SyncReason ProfilerNexusMessage::getSyncReason()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_SYNC:
+		return sync.sync;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		return directBranchWS.sync;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		return indirectBranchWS.sync;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		return indirectHistoryWS.sync;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return TraceDqrProfiler::SYNC_NONE;
+}
+
+uint8_t ProfilerNexusMessage::getEType()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_ERROR:
+		return error.etype;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint8_t ProfilerNexusMessage::getCKDF()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		return ict.ckdf;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		return ictWS.ckdf;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+TraceDqrProfiler::ICTReason ProfilerNexusMessage::getCKSRC()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		return ict.cksrc;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		return ictWS.cksrc;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return TraceDqrProfiler::ICT_NONE;
+}
+
+TraceDqrProfiler::ADDRESS ProfilerNexusMessage::getCKData(int i)
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		return ict.ckdata[i];
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		return ictWS.ckdata[i];
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint8_t ProfilerNexusMessage::getCDF()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		return correlation.cdf;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint8_t ProfilerNexusMessage::getEVCode()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		return correlation.evcode;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		break;
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint32_t ProfilerNexusMessage::getData()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+		return dataAcquisition.data;
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+		return auxAccessWrite.data;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint32_t ProfilerNexusMessage::getAddr()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+		return auxAccessWrite.data;
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint32_t ProfilerNexusMessage::getIdTag()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+		return dataAcquisition.idTag;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint32_t ProfilerNexusMessage::getProcess()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+		return ownership.process;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint32_t ProfilerNexusMessage::getRCode()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		return resourceFull.rCode;
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint64_t ProfilerNexusMessage::getRData()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		switch (resourceFull.rCode) {
+		case 0:
+			return (uint64_t)resourceFull.i_cnt;
+		case 1:
+			return resourceFull.history;
+		case 8:
+			return (uint64_t)resourceFull.notTakenCount;
+		case 9:
+			return (uint64_t)resourceFull.takenCount;
+		default:
+			break;
+		}
+		return 0;
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+uint64_t ProfilerNexusMessage::getHistory()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		if (resourceFull.rCode == 1) {
+			return resourceFull.history;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		return correlation.history;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		return indirectHistory.history;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		return indirectHistoryWS.history;
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_SYNC:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+bool ProfilerNexusMessage::processITCPrintData(ITCPrint* itcPrint)
+{
+	bool rc = false;
+
+	// need to only do this once per message! Return true if the message is an itc print or itc perf message
+	// and it has been consumed. Otherwise, false
+
+	if (itcPrint != nullptr) {
+		switch (tcode) {
+		case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+			rc = itcPrint->print(coreId, dataAcquisition.idTag, dataAcquisition.data, time);
+			break;
+		case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			rc = itcPrint->print(coreId, auxAccessWrite.addr, auxAccessWrite.data, time);
+			break;
+		default:
+			break;
+		}
+	}
+
+	return rc;
+}
+
+std::string ProfilerNexusMessage::messageToString(int detailLevel)
+{
+	char dst[512];
+
+	messageToText(dst, sizeof dst, detailLevel);
+
+	return std::string(dst);
+}
+
+void  ProfilerNexusMessage::messageToText(char* dst, size_t dst_len, int level)
+{
+	if ((dst == nullptr) || (dst_len <= 0)) {
+		printf("Error: ProfilerNexusMessage::messageToText(): Bad dst pointer\n");
+		return;
+	}
+
+	const char* sr;
+	const char* bt;
+	int n;
+
+	// level = 0, itcprint (always process itc print info)
+	// level = 1, timestamp + target + itcprint
+	// level = 2, message info + timestamp + target + itcprint
+	// level = 3, message info + timestamp + target + itcprint + raw trace data
+
+	if (level <= 0) {
+		dst[0] = 0;
+		return;
+	}
+
+	n = snprintf(dst, dst_len, "Msg # %d, ", msgNum);
+
+	if (level >= 3) {
+		n += snprintf(dst + n, dst_len - n, "Offset %d, ", offset);
+
+		int i = 0;
+
+		do {
+			if (i > 0) {
+				n += snprintf(dst + n, dst_len - n, ":%02x", rawData[i]);
+			}
+			else {
+				n += snprintf(dst + n, dst_len - n, "%02x", rawData[i]);
+			}
+			i += 1;
+		} while (((size_t)i < sizeof rawData / sizeof rawData[0]) && ((rawData[i - 1] & 0x3) != TraceDqrProfiler::MSEO_END));
+		n += snprintf(dst + n, dst_len - n, ", ");
+	}
+
+	if (haveTimestamp) {
+		if (ProfilerNexusMessage::targetFrequency != 0) {
+			n += snprintf(dst + n, dst_len - n, "time: %0.8f, ", ((double)time) / ProfilerNexusMessage::targetFrequency);
+		}
+		else {
+			n += snprintf(dst + n, dst_len - n, "Tics: %llu, ", time);
+		}
+	}
+
+	if ((tcode != TraceDqrProfiler::TCODE_INCIRCUITTRACE) && (tcode != TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS)) {
+		n += snprintf(dst + n, dst_len - n, "NxtAddr: %08llx, TCode: ", currentAddress);
+	}
+
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+		snprintf(dst + n, dst_len - n, "DEBUG STATUS (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+		snprintf(dst + n, dst_len - n, "DEVICE ID (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+		n += snprintf(dst + n, dst_len - n, "OWNERSHIP TRACE (%d)", tcode);
+
+		if (level >= 2) {
+			snprintf(dst + n, dst_len - n, " process: %d", ownership.process);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+		n += snprintf(dst + n, dst_len - n, "DIRECT BRANCH (%d)", tcode);
+		if (level >= 2) {
+			snprintf(dst + n, dst_len - n, " I-CNT: %d", directBranch.i_cnt);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		n += snprintf(dst + n, dst_len - n, "INDIRECT BRANCH (%d)", tcode);
+
+		if (level >= 2) {
+			switch (indirectBranch.b_type) {
+			case TraceDqrProfiler::BTYPE_INDIRECT:
+				bt = "Indirect";
+				break;
+			case TraceDqrProfiler::BTYPE_EXCEPTION:
+				bt = "Exception";
+				break;
+			case TraceDqrProfiler::BTYPE_HARDWARE:
+				bt = "Hardware";
+				break;
+			case TraceDqrProfiler::BTYPE_UNDEFINED:
+				bt = "Undefined";
+				break;
+			default:
+				bt = "Bad Branch Type";
+				break;
+			}
+
+			snprintf(dst + n, dst_len - n, " Branch Type: %s (%d) I-CNT: %d U-ADDR: 0x%08llx ", bt, indirectBranch.b_type, indirectBranch.i_cnt, indirectBranch.u_addr);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+		snprintf(dst + n, dst_len - n, "DATA WRITE (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_DATA_READ:
+		snprintf(dst + n, dst_len - n, "DATA READ (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_ERROR:
+		n += snprintf(dst + n, dst_len - n, "ERROR (%d)", tcode);
+		if (level >= 2) {
+			snprintf(dst + n, dst_len - n, " Error Type %d", error.etype);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_SYNC:
+		n += snprintf(dst + n, dst_len - n, "SYNC (%d)", tcode);
+
+		if (level >= 2) {
+			switch (sync.sync) {
+			case TraceDqrProfiler::SYNC_EVTI:
+				sr = "EVTI";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_RESET:
+				sr = "Exit Reset";
+				break;
+			case TraceDqrProfiler::SYNC_T_CNT:
+				sr = "T Count";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_DEBUG:
+				sr = "Exit Debug";
+				break;
+			case TraceDqrProfiler::SYNC_I_CNT_OVERFLOW:
+				sr = "I-Count Overflow";
+				break;
+			case TraceDqrProfiler::SYNC_TRACE_ENABLE:
+				sr = "TraceProfiler Enable";
+				break;
+			case TraceDqrProfiler::SYNC_WATCHPINT:
+				sr = "Watchpoint";
+				break;
+			case TraceDqrProfiler::SYNC_FIFO_OVERRUN:
+				sr = "FIFO Overrun";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_POWERDOWN:
+				sr = "Exit Powerdown";
+				break;
+			case TraceDqrProfiler::SYNC_MESSAGE_CONTENTION:
+				sr = "Message Contention";
+				break;
+			case TraceDqrProfiler::SYNC_PC_SAMPLE:
+				sr = "PC Sample";
+				break;
+			case TraceDqrProfiler::SYNC_NONE:
+				sr = "None";
+				break;
+			default:
+				sr = "Bad Sync Reason";
+				break;
+			}
+
+			snprintf(dst + n, dst_len - n, " Reason: (%d) %s I-CNT: %d F-Addr: 0x%08llx", sync.sync, sr, sync.i_cnt, sync.f_addr);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_CORRECTION:
+		snprintf(dst + n, dst_len - n, "Correction (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		n += snprintf(dst + n, dst_len - n, "DIRECT BRANCH WS (%d)", tcode);
+
+		if (level >= 2) {
+			switch (directBranchWS.sync) {
+			case TraceDqrProfiler::SYNC_EVTI:
+				sr = "EVTI";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_RESET:
+				sr = "Exit Reset";
+				break;
+			case TraceDqrProfiler::SYNC_T_CNT:
+				sr = "T Count";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_DEBUG:
+				sr = "Exit Debug";
+				break;
+			case TraceDqrProfiler::SYNC_I_CNT_OVERFLOW:
+				sr = "I-Count Overflow";
+				break;
+			case TraceDqrProfiler::SYNC_TRACE_ENABLE:
+				sr = "TraceProfiler Enable";
+				break;
+			case TraceDqrProfiler::SYNC_WATCHPINT:
+				sr = "Watchpoint";
+				break;
+			case TraceDqrProfiler::SYNC_FIFO_OVERRUN:
+				sr = "FIFO Overrun";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_POWERDOWN:
+				sr = "Exit Powerdown";
+				break;
+			case TraceDqrProfiler::SYNC_MESSAGE_CONTENTION:
+				sr = "Message Contention";
+				break;
+			case TraceDqrProfiler::SYNC_PC_SAMPLE:
+				sr = "PC Sample";
+				break;
+			case TraceDqrProfiler::SYNC_NONE:
+				sr = "None";
+				break;
+			default:
+				sr = "Bad Sync Reason";
+				break;
+			}
+
+			snprintf(dst + n, dst_len - n, " Reason: (%d) %s I-CNT: %d F-Addr: 0x%08llx", directBranchWS.sync, sr, directBranchWS.i_cnt, directBranchWS.f_addr);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		n += snprintf(dst + n, dst_len - n, "INDIRECT BRANCH WS (%d)", tcode);
+
+		if (level >= 2) {
+			switch (indirectBranchWS.sync) {
+			case TraceDqrProfiler::SYNC_EVTI:
+				sr = "EVTI";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_RESET:
+				sr = "Exit Reset";
+				break;
+			case TraceDqrProfiler::SYNC_T_CNT:
+				sr = "T Count";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_DEBUG:
+				sr = "Exit Debug";
+				break;
+			case TraceDqrProfiler::SYNC_I_CNT_OVERFLOW:
+				sr = "I-Count Overflow";
+				break;
+			case TraceDqrProfiler::SYNC_TRACE_ENABLE:
+				sr = "TraceProfiler Enable";
+				break;
+			case TraceDqrProfiler::SYNC_WATCHPINT:
+				sr = "Watchpoint";
+				break;
+			case TraceDqrProfiler::SYNC_FIFO_OVERRUN:
+				sr = "FIFO Overrun";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_POWERDOWN:
+				sr = "Exit Powerdown";
+				break;
+			case TraceDqrProfiler::SYNC_MESSAGE_CONTENTION:
+				sr = "Message Contention";
+				break;
+			case TraceDqrProfiler::SYNC_PC_SAMPLE:
+				sr = "PC Sample";
+				break;
+			case TraceDqrProfiler::SYNC_NONE:
+				sr = "None";
+				break;
+			default:
+				sr = "Bad Sync Reason";
+				break;
+			}
+
+			switch (indirectBranchWS.b_type) {
+			case TraceDqrProfiler::BTYPE_INDIRECT:
+				bt = "Indirect";
+				break;
+			case TraceDqrProfiler::BTYPE_EXCEPTION:
+				bt = "Exception";
+				break;
+			case TraceDqrProfiler::BTYPE_HARDWARE:
+				bt = "Hardware";
+				break;
+			case TraceDqrProfiler::BTYPE_UNDEFINED:
+				bt = "Undefined";
+				break;
+			default:
+				bt = "Bad Branch Type";
+				break;
+			}
+
+			snprintf(dst + n, dst_len - n, " Reason: (%d) %s Branch Type %s (%d) I-CNT: %d F-Addr: 0x%08llx", indirectBranchWS.sync, sr, bt, indirectBranchWS.b_type, indirectBranchWS.i_cnt, indirectBranchWS.f_addr);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+		snprintf(dst + n, dst_len - n, "DATA WRITE WS (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+		snprintf(dst + n, dst_len - n, "DATA READ WS (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+		snprintf(dst + n, dst_len - n, "TCode: WATCHPOINT (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+		snprintf(dst + n, dst_len - n, "OUTPUT PORT REPLACEMENT (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+		snprintf(dst + n, dst_len - n, "INPUT PORT REPLACEMENT (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+		snprintf(dst + n, dst_len - n, "AUX ACCESS READ (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+		n += snprintf(dst + n, dst_len - n, "DATA ACQUISITION (%d)", tcode);
+
+		if (level >= 2) { // here, if addr not on word boudry, have a partial write!
+			switch (dataAcquisition.idTag & 0x03) {
+			case 0:
+			case 1:
+				snprintf(dst + n, dst_len - n, " idTag: 0x%08x Data: 0x%08x", dataAcquisition.idTag, dataAcquisition.data);
+				break;
+			case 2:
+				snprintf(dst + n, dst_len - n, " idTag: 0x%08x Data: 0x%04x", dataAcquisition.idTag, (uint16_t)dataAcquisition.data);
+				break;
+			case 3:
+				snprintf(dst + n, dst_len - n, " idTag: 0x%08x Data: 0x%02x", dataAcquisition.idTag, (uint8_t)dataAcquisition.data);
+				break;
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+		n += snprintf(dst + n, dst_len - n, "AUX ACCESS WRITE (%d)", tcode);
+
+		if (level >= 2) { // here, if addr not on word boudry, have a partial write!
+			switch (auxAccessWrite.addr & 0x03) {
+			case 0:
+			case 1:
+				snprintf(dst + n, dst_len - n, " Addr: 0x%08x Data: 0x%08x", auxAccessWrite.addr, auxAccessWrite.data);
+				break;
+			case 2:
+				snprintf(dst + n, dst_len - n, " Addr: 0x%08x Data: 0x%04x", auxAccessWrite.addr, (uint16_t)auxAccessWrite.data);
+				break;
+			case 3:
+				snprintf(dst + n, dst_len - n, " Addr: 0x%08x Data: 0x%02x", auxAccessWrite.addr, (uint8_t)auxAccessWrite.data);
+				break;
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+		snprintf(dst + n, dst_len - n, "AUX ACCESS READNEXT (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+		snprintf(dst + n, dst_len - n, "AUX ACCESS WRITENEXT (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+		snprintf(dst + n, dst_len - n, "AUXACCESS RESPOINSE (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		n += snprintf(dst + n, dst_len - n, "RESOURCE FULL (%d)", tcode);
+
+		if (level >= 2) { // here, if addr not on word boudry, have a partial write!
+			n += snprintf(dst + n, dst_len - n, " RCode: %d", resourceFull.rCode);
+
+			switch (resourceFull.rCode) {
+			case 0:
+				snprintf(dst + n, dst_len - n, " I-CNT: %d", resourceFull.i_cnt);
+				break;
+			case 1:
+				snprintf(dst + n, dst_len - n, " History: 0x%08llx", resourceFull.history);
+				break;
+			case 8:
+				snprintf(dst + n, dst_len - n, " Not Taken Count: %u", resourceFull.notTakenCount);
+				break;
+			case 9:
+				snprintf(dst + n, dst_len - n, " Taken Count: %u", resourceFull.takenCount);
+				break;
+			default:
+				snprintf(dst + n, dst_len - n, " Invalid rCode");
+				break;
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		n += snprintf(dst + n, dst_len - n, "INDIRECT BRANCH HISTORY (%d)", tcode);
+
+		if (level >= 2) {
+			switch (indirectHistory.b_type) {
+			case TraceDqrProfiler::BTYPE_INDIRECT:
+				bt = "Indirect";
+				break;
+			case TraceDqrProfiler::BTYPE_EXCEPTION:
+				bt = "Exception";
+				break;
+			case TraceDqrProfiler::BTYPE_HARDWARE:
+				bt = "Hardware";
+				break;
+			case TraceDqrProfiler::BTYPE_UNDEFINED:
+				bt = "Undefined";
+				break;
+			default:
+				bt = "Bad Branch Type";
+				break;
+			}
+
+			snprintf(dst + n, dst_len - n, " Branch Type: %s (%d) I-CNT: %d U-ADDR: 0x%08llx History: 0x%08llx", bt, indirectHistory.b_type, indirectHistory.i_cnt, indirectHistory.u_addr, indirectHistory.history);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		n += snprintf(dst + n, dst_len - n, "INDIRECT BRANCH HISTORY WS (%d)", tcode);
+
+		if (level >= 2) {
+			switch (indirectHistoryWS.sync) {
+			case TraceDqrProfiler::SYNC_EVTI:
+				sr = "EVTI";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_RESET:
+				sr = "Exit Reset";
+				break;
+			case TraceDqrProfiler::SYNC_T_CNT:
+				sr = "T Count";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_DEBUG:
+				sr = "Exit Debug";
+				break;
+			case TraceDqrProfiler::SYNC_I_CNT_OVERFLOW:
+				sr = "I-Count Overflow";
+				break;
+			case TraceDqrProfiler::SYNC_TRACE_ENABLE:
+				sr = "TraceProfiler Enable";
+				break;
+			case TraceDqrProfiler::SYNC_WATCHPINT:
+				sr = "Watchpoint";
+				break;
+			case TraceDqrProfiler::SYNC_FIFO_OVERRUN:
+				sr = "FIFO Overrun";
+				break;
+			case TraceDqrProfiler::SYNC_EXIT_POWERDOWN:
+				sr = "Exit Powerdown";
+				break;
+			case TraceDqrProfiler::SYNC_MESSAGE_CONTENTION:
+				sr = "Message Contention";
+				break;
+			case TraceDqrProfiler::SYNC_PC_SAMPLE:
+				sr = "PC Sample";
+				break;
+			case TraceDqrProfiler::SYNC_NONE:
+				sr = "None";
+				break;
+			default:
+				sr = "Bad Sync Reason";
+				break;
+			}
+
+			switch (indirectHistoryWS.b_type) {
+			case TraceDqrProfiler::BTYPE_INDIRECT:
+				bt = "Indirect";
+				break;
+			case TraceDqrProfiler::BTYPE_EXCEPTION:
+				bt = "Exception";
+				break;
+			case TraceDqrProfiler::BTYPE_HARDWARE:
+				bt = "Hardware";
+				break;
+			case TraceDqrProfiler::BTYPE_UNDEFINED:
+				bt = "Undefined";
+				break;
+			default:
+				bt = "Bad Branch Type";
+				break;
+			}
+
+			snprintf(dst + n, dst_len - n, " Reason: (%d) %s Branch Type %s (%d) I-CNT: %d F-Addr: 0x%08llx History: 0x%08llx", indirectHistoryWS.sync, sr, bt, indirectHistoryWS.b_type, indirectHistoryWS.i_cnt, indirectHistoryWS.f_addr, indirectHistoryWS.history);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+		snprintf(dst + n, dst_len - n, "REPEAT BRANCH (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+		snprintf(dst + n, dst_len - n, "REPEAT INSTRUCTION (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+		snprintf(dst + n, dst_len - n, "REPEAT INSTRUCTIN WS (%d)", tcode);
+		break;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		n += snprintf(dst + n, dst_len - n, "CORRELATION (%d)", tcode);
+
+		if (level >= 2) {
+			n += snprintf(dst + n, dst_len - n, " EVCODE: %d CDF: %d I-CNT: %d", correlation.evcode, correlation.cdf, correlation.i_cnt);
+			if (correlation.cdf > 0) {
+				snprintf(dst + n, dst_len - n, " History: 0x%08llx", correlation.history);
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		if ((ict.cksrc == TraceDqrProfiler::ICT_CONTROL) && (ict.ckdf == 0)) {
+			n += snprintf(dst + n, dst_len - n, "TCode: INCIRCUITTRACE (%d)", tcode);
+		}
+		else {
+			n += snprintf(dst + n, dst_len - n, "Address: %08llx TCode: INCIRCUITTRACE (%d)", currentAddress, tcode);
+		}
+
+		if (level >= 2) {
+			switch (ict.cksrc) {
+			case TraceDqrProfiler::ICT_EXT_TRIG:
+				if (ict.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: External Trigger (%d) U-ADDR: 0x%08llx", ict.cksrc, ict.ckdata[0]);
+				}
+				else if (ict.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: External Trigger + ID (%d) Trigger ID %d U-ADDR: 0x%08llx", ict.cksrc, (int)ict.ckdata[1], ict.ckdata[0]);
+				}
+				else {
+					printf("Error: messageToText(): ICT_EXTERNAL_TRIG: invalid ict.ckdf value: %d\n", ict.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_EXTERNAL_TRIG: invalid ict.ckdf value: %d", ict.ckdf);
+				}
+				break;
+			case TraceDqrProfiler::ICT_WATCHPOINT:
+				if (ict.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Watchpoint (%d) U-ADDR: 0x%08llx", ict.cksrc, ict.ckdata[0]);
+				}
+				else if (ict.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Watchpoint + ID (%d) Trigger ID %d U-ADDR: 0x%08llx", ict.cksrc, (int)ict.ckdata[1], ict.ckdata[0]);
+				}
+				else {
+					printf("Error: messageToText(): ICT_WATCHPOINT: invalid ict.ckdf value: %d\n", ict.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_WATCHPOINT: invalid ict.ckdf value: %d", ict.ckdf);
+				}
+				break;
+			case TraceDqrProfiler::ICT_INFERABLECALL:
+				if (ict.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Inferable Call (%d) U-ADDR: 0x%08llx", ict.cksrc, ict.ckdata[0]);
+				}
+				else if (ict.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Call/Return (%d) U-ADDR: 0x%08llx PCdest 0x%08llx", ict.cksrc, ict.ckdata[0], currentAddress ^ (ict.ckdata[1] << 1));
+				}
+				else {
+					printf("Error: messageToText(): ICT_INFERABLECALL: invalid ict.ckdf value: %d\n", ict.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_INFERABLECALL: invalid ict.ckdf value: %d", ict.ckdf);
+				}
+				break;
+			case TraceDqrProfiler::ICT_EXCEPTION:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Exception (%d) Cause %d U-ADDR: 0x%08llx", ict.cksrc, (int)ict.ckdata[1], ict.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_INTERRUPT:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Interrupt (%d) Cause %d U-ADDR: 0x%08llx", ict.cksrc, (int)ict.ckdata[1], ict.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_CONTEXT:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Context (%d) Context %d U-ADDR: 0x%08llx", ict.cksrc, (int)ict.ckdata[1], ict.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_PC_SAMPLE:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Periodic (%d) U-ADDR: 0x%08llx", ict.cksrc, ict.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_CONTROL:
+				if (ict.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Control (%d) Control %d", ict.cksrc, (int)ict.ckdata[0]);
+				}
+				else if (ict.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Control (%d) Control %d U-ADDR: 0x%08llx", ict.cksrc, (int)ict.ckdata[1], ict.ckdata[0]);
+				}
+				else {
+					printf("Error: messageToText(): ICT_CONTROL: invalid ict.ckdf value: %d\n", ict.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_CONTROL: invalid ict.ckdf value: %d", ict.ckdf);
+				}
+				break;
+			default:
+				printf("Error: messageToText(): Invalid ICT Event: %d\n", ict.cksrc);
+				snprintf(dst + n, dst_len - n, " Error: messageToText(): Invalid ICT Event: %d", ict.cksrc);
+				break;
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		if ((ictWS.cksrc == TraceDqrProfiler::ICT_CONTROL) && (ictWS.ckdf == 0)) {
+			n += snprintf(dst + n, dst_len - n, "TCode: INCIRCUITTRACE WS (%d)", tcode);
+		}
+		else {
+			n += snprintf(dst + n, dst_len - n, "Address: %08llx TCode: INCIRCUITTRACE WS (%d)", currentAddress, tcode);
+		}
+
+		if (level >= 2) {
+			switch (ictWS.cksrc) {
+			case TraceDqrProfiler::ICT_EXT_TRIG:
+				if (ictWS.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: External Trigger (%d) F-ADDR: 0x%08llx", ictWS.cksrc, ictWS.ckdata[0]);
+				}
+				else if (ictWS.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: External Trigger + ID (%d) Trigger ID %d F-ADDR: 0x%08llx", ictWS.cksrc, (int)ictWS.ckdata[1], ictWS.ckdata[0]);
+				}
+				else {
+					printf("Error: messageToText(): ICT_EXTERNAL_TRIG: invalid ictWS.ckdf value: %d\n", ictWS.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_EXTERNAL_TRIG: invalid ictWS.ckdf value: %d", ictWS.ckdf);
+				}
+				break;
+			case TraceDqrProfiler::ICT_WATCHPOINT:
+				if (ictWS.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Watchpoint (%d) U-ADDR: 0x%08llx", ictWS.cksrc, ictWS.ckdata[0]);
+				}
+				else if (ictWS.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Watchpoint + ID (%d) Trigger ID %d F-ADDR: 0x%08llx", ictWS.cksrc, (int)ictWS.ckdata[1], ictWS.ckdata[0]);
+				}
+				else {
+					printf("Error: messageToText(): ICT_WATCHPOINT: invalid ictWS.ckdf value: %d\n", ictWS.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_WATCHPOINT: invalid ictWS.ckdf value: %d", ictWS.ckdf);
+				}
+				break;
+			case TraceDqrProfiler::ICT_INFERABLECALL:
+				if (ictWS.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Inferable Call (%d) F-ADDR: 0x%08llx", ictWS.cksrc, ictWS.ckdata[0]);
+				}
+				else if (ictWS.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Call/Return (%d) F-ADDR: 0x%08llx PCdest 0x%08llx", ictWS.cksrc, ictWS.ckdata[0], currentAddress ^ (ictWS.ckdata[1] << 1));
+				}
+				else {
+					printf("Error: messageToText(): ICT_INFERABLECALL: invalid ictWS.ckdf value: %d\n", ictWS.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_INFERABLECALL: invalid ictWS.ckdf value: %d", ictWS.ckdf);
+				}
+				break;
+			case TraceDqrProfiler::ICT_EXCEPTION:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Exception (%d) Cause %d F-ADDR: 0x%08llx", ictWS.cksrc, (int)ictWS.ckdata[1], ictWS.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_INTERRUPT:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Interrupt (%d) Cause %d F-ADDR: 0x%08llx", ictWS.cksrc, (int)ictWS.ckdata[1], ictWS.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_CONTEXT:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Context (%d) Context %d F-ADDR: 0x%08llx", ictWS.cksrc, (int)ictWS.ckdata[1], ictWS.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_PC_SAMPLE:
+				snprintf(dst + n, dst_len - n, " ICT Reason: Periodic (%d) F-ADDR: 0x%08llx", ictWS.cksrc, ictWS.ckdata[0]);
+				break;
+			case TraceDqrProfiler::ICT_CONTROL:
+				if (ictWS.ckdf == 0) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Control (%d) Control %d", ictWS.cksrc, (int)ictWS.ckdata[0]);
+				}
+				else if (ictWS.ckdf == 1) {
+					snprintf(dst + n, dst_len - n, " ICT Reason: Control (%d) Control %d F-ADDR: 0x%08llx", ictWS.cksrc, (int)ictWS.ckdata[1], ictWS.ckdata[0]);
+				}
+				else {
+					printf("Error: messageToText(): ICT_CONTROL: invalid ictWS.ckdf value: %d\n", ictWS.ckdf);
+					snprintf(dst + n, dst_len - n, " Error: messageToText(): ICT_CONTROL: invalid ictWS.ckdf value: %d", ictWS.ckdf);
+				}
+				break;
+			default:
+				printf("Error: messageToText(): Invalid ICT Event: %d\n", ictWS.cksrc);
+				snprintf(dst + n, dst_len - n, " Error: messageToText(): Invalid ICT Event: %d", ictWS.cksrc);
+				break;
+			}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+		snprintf(dst + n, dst_len - n, "UNDEFINED (%d)", tcode);
+		break;
+	default:
+		snprintf(dst + n, dst_len - n, "BAD TCODE (%d)", tcode);
+		break;
+	}
+}
+
+double ProfilerNexusMessage::seconds()
+{
+	if (haveTimestamp == false) {
+		return 0.0;
+	}
+
+	if (targetFrequency != 0) {
+		return ((double)time) / targetFrequency;
+	}
+
+	return (double)time;
+}
+
+void ProfilerNexusMessage::dumpRawMessage()
+{
+	int i;
+
+	printf("Raw Message # %d: ", msgNum);
+
+	for (i = 0; ((size_t)i < sizeof rawData / sizeof rawData[0]) && ((rawData[i] & 0x03) != TraceDqrProfiler::MSEO_END); i++) {
+		printf("%02x ", rawData[i]);
+	}
+
+	if ((size_t)i < sizeof rawData / sizeof rawData[0]) {
+		printf("%02x\n", rawData[i]);
+	}
+	else {
+		printf("no end of message\n");
+	}
+}
+
+void ProfilerNexusMessage::dump()
+{
+	switch (tcode) {
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+		std::cout << "unsupported debug status trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+		std::cout << "unsupported device id trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Ownership, process=" << ownership.process << std::endl; // << ", TS=0x" << hex << timestamp << dec; // << endl;
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+		//		cout << "(" << traceNum << ") ";
+		//		cout << "  | Direct Branch | TYPE=DBM, ICNT=" << i_cnt << ", TS=0x" << hex << timestamp << dec; // << endl;
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Direct Branch, ICNT=" << directBranch.i_cnt << std::endl; // << ", TS=0x" << hex << timestamp << dec; // << endl;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		//		cout << "(" << traceNum << ") ";
+		//		cout << "  | Indirect Branch | TYPE=IBM, BTYPE=" << b_type << ", ICNT=" << i_cnt << ", UADDR=0x" << hex << u_addr << ", TS=0x" << timestamp << dec;// << endl;
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Indirect Branch, BTYPE=" << indirectBranch.b_type << ", ICNT=" << indirectBranch.i_cnt << ", UADDR=0x" << std::hex << indirectBranch.u_addr << std::dec << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+		break;
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		switch (resourceFull.rCode) {
+		case 0:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): Resource Full, rCode=" << resourceFull.rCode << ", ICNT=" << resourceFull.i_cnt << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+			break;
+		case 1:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): Resource Full, rCode=" << resourceFull.rCode << ", History=0x" << std::hex << resourceFull.history << std::dec << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+			break;
+		case 8:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): Resource Full, rCode=" << resourceFull.rCode << ", Not taken=" << resourceFull.notTakenCount << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+			break;
+		case 9:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): Resource Full, rCode=" << resourceFull.rCode << ", Taken=" << resourceFull.takenCount << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+			break;
+		default:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): Resource Full, Invalid or unsupported rCode for reourceFull TCODE" << std::endl;
+			break;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Indirect Branch History, ICNT=" << indirectHistory.i_cnt << ", BTYPE=" << indirectHistory.b_type << ", UADDR=0x" << std::hex << indirectHistory.u_addr << std::dec << ", history=0x" << std::hex << indirectHistory.history << std::dec << std::endl;
+		break;
+		//	case TCODE_INDIRECTBRANCHHISTORY_WS:
+		//	case TCODE_CORRELATION:
+		//	case TCODE_INCIRCUITTRACE:
+		//	case TCODE_INCIRCUITTRACE_WS:
+		//		break;
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+		std::cout << "unsupported data write trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_DATA_READ:
+		std::cout << "unsupported data read trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+		std::cout << "unsupported data acquisition trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_ERROR:
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Error, ETYPE=" << (uint32_t)error.etype << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+		break;
+	case TraceDqrProfiler::TCODE_SYNC:
+		//		cout << "(" << traceNum << "," << syncNum << ") ";
+		//		cout << "  | Sync | TYPE=SYNC, SYNC=" << sync << ", ICNT=" << i_cnt << ", FADDR=0x" << hex << f_addr << ", TS=0x" << timestamp << dec;// << endl;
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Sync, SYNCREASON=" << sync.sync << ", ICNT=" << sync.i_cnt << ", FADDR=0x" << std::hex << sync.f_addr << std::dec << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+		break;
+	case TraceDqrProfiler::TCODE_CORRECTION:
+		std::cout << "unsupported correction trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		//		cout << "(" << traceNum << "," << syncNum << ") ";
+		//		cout << "  | Direct Branch With Sync | TYPE=DBWS, SYNC=" << sync << ", ICNT=" << i_cnt << ", FADDR=0x" << hex << f_addr << ", TS=0x" << timestamp << dec;// << endl;
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Direct Branch With Sync, SYNCTYPE=" << directBranchWS.sync << ", ICNT=" << directBranchWS.i_cnt << ", FADDR=0x" << std::hex << directBranchWS.f_addr << std::dec << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		//		cout << "(" << traceNum << "," << syncNum << ") ";
+		//		cout << "  | Indirect Branch With Sync | TYPE=IBWS, SYNC=" << sync << ", BTYPE=" << b_type << ", ICNT=" << i_cnt << ", FADDR=0x" << hex << f_addr << ", TS=0x" << timestamp << dec;// << endl;
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Indirect Branch With sync, SYNCTYPE=" << indirectBranchWS.sync << ", BTYPE=" << indirectBranchWS.b_type << ", ICNT=" << indirectBranchWS.i_cnt << ", FADDR=0x" << std::hex << indirectBranchWS.f_addr << std::dec << std::endl; // << ", TS=0x" << timestamp << dec;// << endl;
+		break;
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+		std::cout << "unsupported data write with sync trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+		std::cout << "unsupported data read with sync trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+		std::cout << "unsupported watchpoint trace message\n";
+		break;
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Auxillary Access Write, address=" << std::hex << auxAccessWrite.addr << std::dec << ", data=" << std::hex << auxAccessWrite.data << std::dec << std::endl; // << ", TS=0x" << hex << timestamp << dec; // << endl;
+		break;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		std::cout << "  # TraceProfiler Message(" << msgNum << "): Correlation, EVCODE=" << (uint32_t)correlation.evcode << ", CDF=" << (int)correlation.cdf << ", ICNT=" << correlation.i_cnt << "\n"; // << ", TS=0x" << timestamp << dec;// << endl;
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		switch (ict.cksrc) {
+		case TraceDqrProfiler::ICT_EXT_TRIG:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler External Trigger, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec;
+			if (ict.ckdf > 0) {
+				std::cout << ", ID=" << ict.ckdata[1];
+			}
+			std::cout << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_CONTROL:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler Control, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf;
+			if (ict.ckdf > 0) {
+				std::cout << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec << ", Control=" << ict.ckdata[1] << std::endl;
+			}
+			else {
+				std::cout << ", Control=" << ict.ckdata[0] << std::endl;
+			}
+			break;
+		case TraceDqrProfiler::ICT_INFERABLECALL:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler Call/Return, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec;
+			if (ict.ckdf > 0) {
+				std::cout << ", PCDest=0x" << std::hex << ict.ckdata[1] << std::dec;
+			}
+			std::cout << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_EXCEPTION:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler Exception, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec << ", Cause=" << ict.ckdata[1] << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_INTERRUPT:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler Interrupt, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec << ", Cause=" << ict.ckdata[1] << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_CONTEXT:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler Context, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec << ", Context=0x" << std::hex << ict.ckdata[1] << std::dec << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_WATCHPOINT:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler Watchpoint, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec;
+			if (ict.ckdf > 0) {
+				std::cout << ", ID=" << ict.ckdata[1];
+			}
+			std::cout << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_PC_SAMPLE:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler PC Sample, cksrc=" << ict.cksrc << ", ckdf=" << (int)ict.ckdf << ", PC=0x" << std::hex << ict.ckdata[0] << std::dec << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_NONE:
+			break;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		switch (ictWS.cksrc) {
+		case TraceDqrProfiler::ICT_EXT_TRIG:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS External Trigger, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec;
+			if (ictWS.ckdf > 0) {
+				std::cout << ", ID=" << ictWS.ckdata[1];
+			}
+			std::cout << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_CONTROL:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS Control, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf;
+			if (ictWS.ckdf > 0) {
+				std::cout << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec << ", Control=" << ictWS.ckdata[1] << std::endl;
+			}
+			else {
+				std::cout << ", Control=" << ictWS.ckdata[0] << std::endl;
+			}
+			break;
+		case TraceDqrProfiler::ICT_INFERABLECALL:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS Call/Return, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec;
+			if (ictWS.ckdf > 0) {
+				std::cout << ", PCDest=0x" << std::hex << ictWS.ckdata[1] << std::dec;
+			}
+			std::cout << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_EXCEPTION:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS Exception, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec << ", Cause=" << ictWS.ckdata[1] << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_INTERRUPT:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS Interrupt, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec << ", Cause=" << ictWS.ckdata[1] << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_CONTEXT:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS Context, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec << ", Context=0x" << std::hex << ictWS.ckdata[1] << std::dec << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_WATCHPOINT:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS Watchpoint, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec;
+			if (ictWS.ckdf > 0) {
+				std::cout << ", ID=" << ictWS.ckdata[1];
+			}
+			std::cout << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_PC_SAMPLE:
+			std::cout << "  # TraceProfiler Message(" << msgNum << "): In Circuit TraceProfiler WS PC Sample, cksrc=" << ictWS.cksrc << ", ckdf=" << (int)ictWS.ckdf << ", PC=0x" << std::hex << ictWS.ckdata[0] << std::dec << std::endl;
+			break;
+		case TraceDqrProfiler::ICT_NONE:
+			break;
+		}
+		break;
+	default:
+		std::cout << "Error: ProfilerNexusMessage::dump(): Unknown TCODE " << tcode << " (0x" << std::hex << tcode << std::dec << "), msgnum: " << msgNum << std::endl;
+	}
+}
+
+Count::Count()
+{
+	for (int i = 0; i < (int)(sizeof i_cnt / sizeof i_cnt[0]); i++) {
+		i_cnt[i] = 0;
+	}
+
+	for (int i = 0; i < (int)(sizeof history / sizeof history[0]); i++) {
+		history[i] = 0;
+	}
+
+	for (int i = 0; i < (int)(sizeof histBit / sizeof histBit[0]); i++) {
+		histBit[i] = -1;
+	}
+
+	for (int i = 0; i < (int)(sizeof takenCount / sizeof takenCount[0]); i++) {
+		takenCount[i] = 0;
+	}
+
+	for (int i = 0; i < (int)(sizeof notTakenCount / sizeof notTakenCount[0]); i++) {
+		notTakenCount[i] = 0;
+	}
+}
+
+Count::~Count()
+{
+	// nothing to do here!
+}
+
+void Count::resetCounts(int core)
+{
+	i_cnt[core] = 0;
+	histBit[core] = -1;
+	takenCount[core] = 0;
+	notTakenCount[core] = 0;
+}
+
+TraceDqrProfiler::CountType Count::getCurrentCountType(int core)
+{
+	// types are prioritized! Order is important
+
+	if (histBit[core] >= 0) {
+		return TraceDqrProfiler::COUNTTYPE_history;
+	}
+
+	if (takenCount[core] > 0) {
+		return TraceDqrProfiler::COUNTTYPE_taken;
+	}
+
+	if (notTakenCount[core] > 0) {
+		return TraceDqrProfiler::COUNTTYPE_notTaken;
+	}
+
+	// i-cnt is the lowest priority
+
+	if (i_cnt[core] > 0) {
+		return TraceDqrProfiler::COUNTTYPE_i_cnt;
+	}
+
+	//	printf("count type: hist: %d taken:%d not taken:%d i_cnt: %d\n",histBit[core],takenCount[core],notTakenCount[core],i_cnt[core]);
+
+	return TraceDqrProfiler::COUNTTYPE_none;
+}
+
+TraceDqrProfiler::DQErr Count::setICnt(int core, int count)
+{
+	i_cnt[core] += count;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Count::setHistory(int core, uint64_t hist)
+{
+	TraceDqrProfiler::DQErr rc = TraceDqrProfiler::DQERR_OK;
+
+	if (histBit[core] >= 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else if (takenCount[core] != 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else if (notTakenCount[core] != 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else if (hist == 0) {
+		history[core] = 0;
+		histBit[core] = -1;
+	}
+	else {
+		history[core] = hist;
+
+		int i;
+
+		for (i = sizeof hist * 8 - 1; i >= 0; i -= 1) {
+			if (hist & (((uint64_t)1) << i)) {
+				histBit[core] = i - 1;
+				break;
+			}
+		}
+
+		if (i < 0) {
+			histBit[core] = -1;
+		}
+	}
+
+	return rc;
+}
+
+TraceDqrProfiler::DQErr Count::setHistory(int core, uint64_t hist, int count)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	rc = setICnt(core, count);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return rc;
+	}
+
+	rc = setHistory(core, hist);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return rc;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Count::setTakenCount(int core, int takenCnt)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	if (histBit[core] >= 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else if (takenCount[core] != 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else if (notTakenCount[core] != 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else {
+		takenCount[core] = takenCnt;
+		rc = TraceDqrProfiler::DQERR_OK;
+	}
+
+	return rc;
+}
+
+TraceDqrProfiler::DQErr Count::setNotTakenCount(int core, int notTakenCnt)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	if (histBit[core] >= 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else if (takenCount[core] != 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else if (notTakenCount[core] != 0) {
+		rc = TraceDqrProfiler::DQERR_ERR;
+	}
+	else {
+		notTakenCount[core] = notTakenCnt;
+		rc = TraceDqrProfiler::DQERR_OK;
+	}
+
+	return rc;
+}
+
+TraceDqrProfiler::DQErr Count::setCounts(ProfilerNexusMessage* nm)
+{
+	TraceDqrProfiler::DQErr rc;
+	int tmp_i_cnt = 0;
+	uint64_t tmp_history = 0;
+	int tmp_taken = 0;
+	int tmp_notTaken = 0;
+
+	switch (nm->tcode) {
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+	case TraceDqrProfiler::TCODE_ERROR:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		// no counts, do nothing
+		return TraceDqrProfiler::DQERR_OK;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+		tmp_i_cnt = nm->directBranch.i_cnt;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		tmp_i_cnt = nm->indirectBranch.i_cnt;
+		break;
+	case TraceDqrProfiler::TCODE_SYNC:
+		tmp_i_cnt = nm->sync.i_cnt;
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		tmp_i_cnt = nm->directBranchWS.i_cnt;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		tmp_i_cnt = nm->indirectBranchWS.i_cnt;
+		break;
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		switch (nm->resourceFull.rCode) {
+		case 0:
+			tmp_i_cnt = nm->resourceFull.i_cnt;
+			break;
+		case 1:
+			tmp_history = nm->resourceFull.history;
+			break;
+		case 8:
+			tmp_notTaken = nm->resourceFull.notTakenCount;
+			break;
+		case 9:
+			tmp_taken = nm->resourceFull.takenCount;
+			break;
+		default:
+			printf("Error: Count::setCount(): invalid or unsupported rCode for reourceFull TCODE\n");
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		tmp_i_cnt = nm->indirectHistory.i_cnt;
+		tmp_history = nm->indirectHistory.history;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		tmp_i_cnt = nm->indirectHistoryWS.i_cnt;
+		tmp_history = nm->indirectHistoryWS.history;
+		break;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		tmp_i_cnt = nm->correlation.i_cnt;
+		if (nm->correlation.cdf == 1) {
+			tmp_history = nm->correlation.history;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+	default:
+		printf("Error: Count::setCount(): invalid or unsupported TCODE\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (tmp_i_cnt != 0) {
+		rc = setICnt(nm->coreId, tmp_i_cnt);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return rc;
+		}
+	}
+
+	if (tmp_history != 0) {
+		rc = setHistory(nm->coreId, tmp_history);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return rc;
+		}
+	}
+
+	if (tmp_taken != 0) {
+		rc = setTakenCount(nm->coreId, tmp_taken);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return rc;
+		}
+	}
+
+	if (tmp_notTaken != 0) {
+		rc = setNotTakenCount(nm->coreId, tmp_notTaken);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return rc;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+int Count::consumeICnt(int core, int numToConsume)
+{
+	i_cnt[core] -= numToConsume;
+
+	return i_cnt[core];
+}
+
+int Count::consumeHistory(int core, bool& taken)
+{
+	if (histBit[core] < 0) {
+		return 1;
+	}
+
+	taken = (history[core] & (1 << histBit[core])) != 0;
+
+	histBit[core] -= 1;
+
+	return 0;
+}
+
+int Count::consumeTakenCount(int core)
+{
+	if (takenCount[core] <= 0) {
+		return 1;
+	}
+
+	takenCount[core] -= 1;
+
+	return 0;
+}
+
+int Count::consumeNotTakenCount(int core)
+{
+	if (notTakenCount[core] <= 0) {
+		return 1;
+	}
+
+	notTakenCount[core] -= 1;
+
+	return 0;
+}
+
+void Count::dumpCounts(int core)
+{
+	printf("Count::dumpCounts(): core: %d, i_cnt: %d, history: 0x%08llx, histBit: %d, takenCount: %d, notTakenCount: %d\n", core, i_cnt[core], history[core], histBit[core], takenCount[core], notTakenCount[core]);
+}
+
+SliceFileParser::SliceFileParser(char* filename, int srcBits)
+{
+	//if (filename == nullptr) {
+	//	printf("Error: SliceFileParser::SliceFaileParser(): No filename specified\n");
+	//	status = TraceDqrProfiler::DQERR_OK;
+	//	return;
+	//}
+
+	srcbits = srcBits;
+
+	msgSlices = 0;
+	bitIndex = 0;
+
+	pendingMsgIndex = 0;
+
+	tfSize = 0;
+	bufferInIndex = 0;
+	bufferOutIndex = 0;
+
+	eom = false;
+    {
+        std::lock_guard<std::mutex> msg_eod_guard(m_end_of_data_mutex);
+        m_end_of_data = false;
+    }
+
+	int i;
+
+	// first lets see if it is a windows path
+
+	bool havePath = true;
+
+	//for (i = 0; (filename[i] != 0) && (filename[i] != ':'); i++) { /* empty */ }
+
+	//if (filename[i] == ':') {
+	//	// see if this is a disk designator or port designator
+
+	//	int j;
+	//	int numAlpha = 0;
+
+	//	// look for drive : (not a foolproof test, but should work
+
+	//	for (j = 0; j < i; j++) {
+	//		if ((filename[j] >= 'a' && filename[j] <= 'z') || (filename[j] >= 'A' && filename[j] <= 'Z')) {
+	//			numAlpha += 1;
+	//		}
+	//	}
+
+	//	if (numAlpha != 1) {
+	//		havePath = false;
+	//	}
+	//}
+	if (havePath == false) {
+#if 0
+		// have a server:port address
+
+		int rc;
+		char* sn = nullptr;
+		int port = 0;
+
+		sn = new char[i];
+		strncpy(sn, filename, i);
+		sn[i] = 0;
+
+		port = atoi(&filename[i + 1]);
+
+		// create socket
+
+#ifdef WINDOWS
+		WORD wVersionRequested;
+		WSADATA wsaData;
+
+		wVersionRequested = MAKEWORD(2, 2);
+		rc = WSAStartup(wVersionRequested, &wsaData);
+		if (rc != 0) {
+			printf("Error: WSAStartUP() failed with error %d\n", rc);
+			delete[] sn;
+			sn = nullptr;
+			status = TraceDqrProfiler::DQERR_ERR;
+			return;
+		}
+#endif // WINDOWS
+
+		SWTsock = socket(AF_INET, SOCK_STREAM, 0);
+		if (SWTsock < 0) {
+			printf("Error: SliceFileParser::SliceFileParser(); socket() failed\n");
+			delete[] sn;
+			sn = nullptr;
+			status = TraceDqrProfiler::DQERR_ERR;
+			return;
+		}
+
+		struct sockaddr_in serv_addr;
+		struct hostent* server;
+
+		server = gethostbyname(sn);
+
+		delete[] sn;
+		sn = nullptr;
+
+		memset((char*)&serv_addr, 0, sizeof(serv_addr));
+		serv_addr.sin_family = AF_INET;
+		serv_addr.sin_port = htons(port);
+		memcpy((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr, server->h_length);
+
+		rc = connect(SWTsock, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+		if (rc < 0) {
+			printf("Error: SliceFileParser::SliceFileParser(): connect() failed: %d\n", rc);
+
+#ifdef WINDOWS
+			closesocket(SWTsock);
+#else // WINDOWS
+			close(SWTsock);
+#endif // WINDOWS
+
+			SWTsock = -1;
+
+			server = nullptr;
+
+			status = TraceDqrProfiler::DQERR_ERR;
+
+			return;
+		}
+
+		// put socket in non-blocking mode
+#ifdef WINDOWS
+		unsigned long on = 1L;
+		rc = ioctlsocket(SWTsock, FIONBIO, &on);
+		if (rc != NO_ERROR) {
+			printf("Error: SliceFileParser::SliceFileParser(): Failed to put socket into non-blocking mode\n");
+			status = TraceDqrProfiler::DQERR_ERR;
+			return;
+		}
+#else // WINDOWS
+//		long on = 1L;
+//		rc = ioctl(SWTsock,(int)FIONBIO,(char*)&on);
+//		if (rc < 0) {
+//			printf("Error: SliceFileParser::SliceFileParser(): Failed to put socket into non-blocking mode\n");
+//			status = TraceDqrProfiler::DQERR_ERR;
+//			return;
+//		}
+#endif // WINDOWS
+
+		tfSize = 0;
+#endif
+	}
+	else {
+		//tf.open(filename, std::ios::in | std::ios::binary);
+		//if (!tf) {
+		//	printf("Error: SliceFileParder(): could not open file %s for input\n", filename);
+		//	status = TraceDqrProfiler::DQERR_OPEN;
+		//	return;
+		//}
+		//else {
+		//	status = TraceDqrProfiler::DQERR_OK;
+		//}
+
+		//tf.seekg(0, tf.end);
+		//tfSize = tf.tellg();
+		//tf.seekg(0, tf.beg);
+
+		msgOffset = 0;
+
+		SWTsock = -1;
+	}
+
+	status = TraceDqrProfiler::DQERR_OK;
+}
+
+SliceFileParser::~SliceFileParser()
+{
+	if (tf.is_open()) {
+		tf.close();
+	}
+
+//	if (SWTsock >= 0) {
+//#ifdef WINDOWS
+//		closesocket(SWTsock);
+//		WSACleanup();
+//#else  // WINDOWS
+//		close(SWTsock);
+//#endif // WINDOWS
+//
+//		SWTsock = -1;
+//	}
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::getNumBytesInSWTQ(int& numBytes)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	//if (SWTsock < 0) {
+	//	return TraceDqrProfiler::DQERR_ERR;
+	//}
+
+	//rc = bufferSWT();
+	//if (rc != TraceDqrProfiler::DQERR_OK) {
+	//	return rc;
+	//}
+
+	//if (bufferInIndex == bufferOutIndex) {
+	//	numBytes = 0;
+	//}
+	//else if (bufferInIndex < bufferOutIndex) {
+	//	numBytes = (sizeof sockBuffer / sizeof sockBuffer[0]) - bufferOutIndex + bufferInIndex;
+	//}
+	//else { // bufferInIndex > bufferOutIndex
+	//	numBytes = bufferInIndex - bufferOutIndex;
+	//}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::getFileOffset(int& size, int& offset)
+{
+	if (!tf.is_open()) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	size = tfSize;
+	offset = tf.tellg();
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+void SliceFileParser::dump()
+{
+	//msg and msgSlices
+
+	for (int i = 0; i < msgSlices; i++) {
+		std::cout << std::setw(2) << i + 1;
+		std::cout << " | ";
+		std::cout << std::setfill('0');
+		std::cout << std::setw(2) << std::hex << int(msg[i] >> 2) << std::dec;
+		std::cout << std::setfill(' ');
+		std::cout << " | ";
+		std::cout << int((msg[i] >> 1) & 1);
+		std::cout << " ";
+		std::cout << int(msg[i] & 1);
+		std::cout << std::endl;
+	}
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseICT(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;	// start bits at 6 to account for tcode
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_INCIRCUITTRACE;
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the four bit CKSRC (reason for ICT)
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.ict.cksrc = (TraceDqrProfiler::ICTReason)tmp;
+
+	// parse the 2 bit CKDF field (number of CKDATA fields: 0 means 1, etc)
+
+	rc = parseFixedField(2, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 2;
+
+	if (tmp > 1) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return status;
+	}
+
+	nm.ict.ckdf = (uint8_t)tmp;
+
+	for (int i = 0; i <= nm.ict.ckdf; i++) {
+		// parse the variable length CKDATA field
+
+		rc = parseVarField(&tmp, &width);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		addr_bits = width;
+
+		nm.ict.ckdata[i] = (TraceDqrProfiler::ADDRESS)tmp;
+	}
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseICTWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;	// start bits at 6 to account for tcode
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS;
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the four bit CKSRC (reason for ICT)
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.ictWS.cksrc = (TraceDqrProfiler::ICTReason)tmp;
+
+	// parse the 2 bit CKDF field (number of CKDATA fields: 0 means 1, etc)
+
+	rc = parseFixedField(2, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 2;
+
+	if (tmp > 1) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return status;
+	}
+
+	nm.ictWS.ckdf = (uint8_t)tmp;
+
+	for (int i = 0; i <= nm.ictWS.ckdf; i++) {
+		// parse the variable length CKDATA field
+
+		rc = parseVarField(&tmp, &width);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		addr_bits = width;
+
+		nm.ictWS.ckdata[i] = (TraceDqrProfiler::ADDRESS)tmp;
+	}
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseIndirectHistory(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;	// start bits at 6 to account for tcode
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY;
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the two bit b-type
+
+	rc = parseFixedField(2, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 2;
+
+	nm.indirectHistory.b_type = (TraceDqrProfiler::BType)tmp;
+
+	// parse the variable length the i-cnt
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.indirectHistory.i_cnt = (int)tmp;
+
+	// parse the u-addr field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+	addr_bits = width;
+
+	nm.indirectHistory.u_addr = (TraceDqrProfiler::ADDRESS)tmp;
+
+	// parse the variable lenght history field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.indirectHistory.history = tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseIndirectHistoryWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;	// start bits at 6 to account for tcode
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the fixed length sync reason field
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.indirectHistoryWS.sync = (TraceDqrProfiler::SyncReason)tmp;
+
+	// parse the two bit b-type
+
+	rc = parseFixedField(2, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 2;
+
+	nm.indirectHistoryWS.b_type = (TraceDqrProfiler::BType)tmp;
+
+	// parse the variable length the i-cnt
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.indirectHistoryWS.i_cnt = (int)tmp;
+
+	// parse the f-addr field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+	addr_bits = width;
+
+	nm.indirectHistoryWS.f_addr = (TraceDqrProfiler::ADDRESS)tmp;
+
+	// parse the variable length history field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.indirectHistoryWS.history = tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseResourceFull(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;	// start bits at 6 to account for tcode
+	int        ts_bits = 0;
+
+	nm.tcode = TraceDqrProfiler::TCODE_RESOURCEFULL;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the 4 bit RCODE
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.resourceFull.rCode = (int)tmp;
+
+	// parse the vairable length rdata field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	switch (nm.resourceFull.rCode) {
+	case 0:
+		nm.resourceFull.i_cnt = (int)tmp;
+		break;
+	case 1:
+		nm.resourceFull.history = tmp;
+		break;
+	case 8:
+		nm.resourceFull.notTakenCount = (int)tmp;
+		break;
+	case 9:
+		nm.resourceFull.takenCount = (int)tmp;
+		break;
+	default:
+		printf("Error: parseResourceFull(): unknown rCode: %d\n", nm.resourceFull.rCode);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, 0);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseDirectBranch(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;	// start bits at 6 to account for tcode
+	int        ts_bits = 0;
+
+	nm.tcode = TraceDqrProfiler::TCODE_DIRECT_BRANCH;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the variable length the i-cnt
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.directBranch.i_cnt = (int)tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, 0);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseDirectBranchWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the fixed length sync reason field
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.directBranchWS.sync = (TraceDqrProfiler::SyncReason)tmp;
+
+	// parse the variable length the i-cnt
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.directBranchWS.i_cnt = (int)tmp;
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+	addr_bits = width;
+
+	nm.directBranchWS.f_addr = (TraceDqrProfiler::ADDRESS)tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseIndirectBranch(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_INDIRECT_BRANCH;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			//            printf("Error: parseIndirectBranch(): parseFixedField() for srcbits failed\n");
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	//	if (profiler_globalDebugFlag) {
+	//		printf("parseIndirectBranch(): coreId: %d\n",nm.coreId);
+	//	}
+
+		// parse the fixed length b-type
+
+	rc = parseFixedField(2, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		//        printf("Error: parseIndirectBranch(): parseFixedField() for b-type failed\n");
+
+		return status;
+	}
+
+	bits += 2;
+
+	nm.indirectBranch.b_type = (TraceDqrProfiler::BType)tmp;
+
+	//	if (profiler_globalDebugFlag) {
+	//		printf("parseIndirectBranch(): b_type: %d\n",nm.indirectBranch.b_type);
+	//	}
+
+		// parse the variable length the i-cnt
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		//        printf("Error: parseIndirectBranch(): parseVarField() for i-cnt failed\n");
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.indirectBranch.i_cnt = (int)tmp;
+
+	//	if (profiler_globalDebugFlag) {
+	//		printf("parseIndirectBranch(): i_cnt: %d\n",nm.indirectBranch.i_cnt);
+	//	}
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		//        printf("Error: parseIndirectBranch(): parseVarField() for address failed\n");
+
+		return status;
+	}
+
+	bits += width;
+	addr_bits = width;
+
+	nm.indirectBranch.u_addr = (TraceDqrProfiler::ADDRESS)tmp;
+
+	//	if (profiler_globalDebugFlag) {
+	//		printf("parseIndirectBranch(): u_addr: 0x%08llx\n",nm.indirectBranch.u_addr);
+	//	}
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+
+		//		if (profiler_globalDebugFlag) {
+		//			printf("parseIndirectBranch(): no timestamp\n");
+		//		}
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			//	        printf("Error: parseIndirectBranch(): parseFixedField() for timestamp failed\n");
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			printf("Error: parseIndirectBranch(): End of message expected\n");
+
+			return status;
+		}
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+
+		//		if (profiler_globalDebugFlag) {
+		//			printf("parseIndirectBranch(): timestamp: %llu\n",nm.timestamp);
+		//		}
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseIndirectBranchWS(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the fixed length sync field
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.indirectBranchWS.sync = (TraceDqrProfiler::SyncReason)tmp;
+
+	// parse the fixed length b-type
+
+	rc = parseFixedField(2, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 2;
+
+	nm.indirectBranchWS.b_type = (TraceDqrProfiler::BType)tmp;
+
+	// parse the variable length the i-cnt
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.indirectBranchWS.i_cnt = (int)tmp;
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+	addr_bits = width;
+
+	nm.indirectBranchWS.f_addr = (TraceDqrProfiler::ADDRESS)tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseSync(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+	int        addr_bits;
+
+	nm.tcode = TraceDqrProfiler::TCODE_SYNC;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the sync resons
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.sync.sync = (TraceDqrProfiler::SyncReason)tmp;
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.sync.i_cnt = (int)tmp;
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+	addr_bits = width;
+
+	nm.sync.f_addr = (TraceDqrProfiler::ADDRESS)tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, addr_bits);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseCorrelation(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+
+	nm.tcode = TraceDqrProfiler::TCODE_CORRELATION;
+
+	//	printf("parse correlation\n");
+
+		// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the 4-bit evcode field
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.correlation.evcode = (uint8_t)tmp;
+
+	// parse the 2-bit cdf field.
+
+	rc = parseFixedField(2, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 2;
+
+	nm.correlation.cdf = (uint8_t)tmp;
+
+	// parse the variable length i-cnt field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.correlation.i_cnt = (int)tmp;
+
+	switch (nm.correlation.cdf) {
+	case 0:
+		break;
+	case 1:
+		rc = parseVarField(&tmp, &width);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += width;
+
+		nm.correlation.history = tmp;
+
+		break;
+	default:
+		printf("Error: parseCorrelation(): invalid CDF field: %d\n", nm.correlation.cdf);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, 0);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseError(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+
+	nm.tcode = TraceDqrProfiler::TCODE_ERROR;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the 4 bit ETYPE field
+
+	rc = parseFixedField(4, &tmp);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += 4;
+
+	nm.error.etype = (uint8_t)tmp;
+
+	// parse the variable sized padd field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, 0);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseOwnershipTrace(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+
+	nm.tcode = TraceDqrProfiler::TCODE_OWNERSHIP_TRACE;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the variable length process ID field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.ownership.process = (int)tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, 0);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseAuxAccessWrite(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+
+	nm.tcode = TraceDqrProfiler::TCODE_AUXACCESS_WRITE;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the ADDR field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.auxAccessWrite.addr = (uint32_t)tmp;
+
+	// parse the data field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.auxAccessWrite.data = (uint32_t)tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, 0);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseDataAcquisition(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics)
+{
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   tmp;
+	int        width;
+	int        bits = 6;
+	int        ts_bits = 0;
+
+	nm.tcode = TraceDqrProfiler::TCODE_DATA_ACQUISITION;
+
+	// if multicore, parse src field
+
+	if (srcbits > 0) {
+		rc = parseFixedField(srcbits, &tmp);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		bits += srcbits;
+
+		nm.coreId = (uint8_t)tmp;
+	}
+	else {
+		nm.coreId = 0;
+	}
+
+	// parse the idTag field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.dataAcquisition.idTag = (uint32_t)tmp;
+
+	// parse the data field
+
+	rc = parseVarField(&tmp, &width);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		return status;
+	}
+
+	bits += width;
+
+	nm.dataAcquisition.data = (uint32_t)tmp;
+
+	if (eom == true) {
+		nm.haveTimestamp = false;
+		nm.timestamp = 0;
+	}
+	else {
+		rc = parseVarField(&tmp, &width); // this field is optional - check err
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+
+		// check if entire message has been consumed
+
+		if (eom != true) {
+			status = TraceDqrProfiler::DQERR_BM;
+
+			return status;
+		}
+
+		bits += width;
+		ts_bits = width;
+
+		nm.haveTimestamp = true;
+		nm.timestamp = (TraceDqrProfiler::TIMESTAMP)tmp;
+	}
+
+	status = analytics.updateTraceInfo(nm, bits + msgSlices * 2, msgSlices * 2, ts_bits, 0);
+
+	nm.msgNum = analytics.currentTraceMsgNum();
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseFixedField(int width, uint64_t* val)
+{
+	if ((width <= 0) || (val == nullptr)) {
+		printf("Error: SliceFileParser::parseFixedField(): Bad width or val argument\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	uint64_t tmp_val = 0;
+
+	int i;
+	int b;
+
+	i = bitIndex / 6;
+	b = bitIndex % 6;
+
+	//	printf("parseFixedField(): bitIndex:%d, i:%d, b:%d, width: %d\n",bitIndex,i,b,width);
+
+	bitIndex += width;
+
+	// for read error checking we should make sure that the MSEO bits are
+	// correct for this field. But for now, we don't
+
+	if (bitIndex >= msgSlices * 6) {
+		// read past end of message
+
+		status = TraceDqrProfiler::DQERR_EOM;
+
+		return TraceDqrProfiler::DQERR_EOM;
+	}
+
+	if (b + width > 6) {
+		// fixed field crossed byte boundry - get the bits at msg[i]
+
+		// work from lsb's to msb's
+
+		tmp_val = (uint64_t)(msg[i] >> (b + 2));	// add 2 because of the mseo bits
+
+		int consumed = 6 - b;
+		int remainingWidth = width - consumed;
+
+		i += 1;
+
+		//		b = 0; comment this line out because we jsut don't use b anymore. It is 0 for the rest of the call
+
+				// get the middle bits
+
+		while (remainingWidth >= 6) {
+			tmp_val |= ((uint64_t)(msg[i] >> 2)) << consumed;
+			i += 1;
+			remainingWidth -= 6;
+			consumed += 6;
+		}
+
+		// now get the last bits
+
+		if (remainingWidth > 0) {
+			tmp_val |= ((uint64_t)(((uint8_t)(msg[i] << (6 - remainingWidth))) >> (6 - remainingWidth + 2))) << consumed;
+		}
+
+		*val = tmp_val;
+	}
+	else {
+		uint8_t v;
+
+		// strip off upper and lower bits not part of field
+
+		v = msg[i] << (6 - (b + width));
+		v = v >> ((6 - (b + width)) + b + 2);
+
+		*val = uint64_t(v);
+	}
+
+	if ((msg[i] & 0x03) == TraceDqrProfiler::MSEO_END) {
+		eom = true;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::parseVarField(uint64_t* val, int* width)
+{
+	if (val == nullptr) {
+		printf("SliceFileParser::parseVarField(): Bad val argument\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	int i;
+	int b;
+	int w = 0;
+
+	i = bitIndex / 6;
+	b = bitIndex % 6;
+
+	if (i >= msgSlices) {
+		// read past end of message
+
+		status = TraceDqrProfiler::DQERR_EOM;
+
+		return TraceDqrProfiler::DQERR_EOM;
+	}
+
+	uint64_t v;
+
+	// strip off upper and lower bits not part of field
+
+	w = 6 - b;
+
+	//	printf("parseVarField(): bitIndex:%d, (byte index)i:%d, (bit index)b:%d, width: %d, slices: %d\n",bitIndex,i,b,w,msgSlices);
+
+	v = ((uint64_t)msg[i]) >> (b + 2);
+
+	while ((msg[i] & 0x03) == TraceDqrProfiler::MSEO_NORMAL) {
+		i += 1;
+
+		if (i >= msgSlices) {
+			// read past end of message
+
+			status = TraceDqrProfiler::DQERR_ERR;
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		v = v | ((((uint64_t)msg[i]) >> 2) << w);
+		w += 6;
+	}
+
+	// The check for overflow is a bit tricky. A 64 bit number will be encoded as a 66 bit number
+	// because each slice holds 6 bits of data. So a 64 bit number will take 11 slices, and
+	// at first this looks like a 66 bit number, not 64. Bit if the upper two bits of the last slice
+	// are 0, it is a 66 bit number.
+
+	if ((w > (int)sizeof(v) * 8) && ((msg[i] & 0xc0) != 0)) {
+		// variable field overflowed size of v
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if ((msg[i] & 0x03) == TraceDqrProfiler::MSEO_END) {
+		eom = true;
+	}
+
+	bitIndex += w;
+
+	*width = w;
+	*val = v;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::bufferSWT()
+{
+	int br = 0;
+	int bytesToRead;
+#if 0
+	// compute room in buffer for read
+
+	if (bufferInIndex == bufferOutIndex) {
+		// buffer is empty
+
+		bytesToRead = (sizeof sockBuffer) - 1;
+
+#ifdef WINDOWS
+		br = recv(SWTsock, (char*)sockBuffer, bytesToRead, 0);
+#else // WINDOWS
+		br = recv(SWTsock, (char*)sockBuffer, bytesToRead, MSG_DONTWAIT);
+
+		if (br < 0) {
+			if ((errno != EAGAIN) && (errno != EWOULDBLOCK)) {
+				perror("SliceFileParser::bufferSWT(): recv() error");
+			}
+		}
+#endif // WINDOWS
+
+		if (br > 0) {
+			bufferInIndex = br;
+			bufferOutIndex = 0;
+		}
+	}
+	else if (bufferInIndex < bufferOutIndex) {
+		// empty bytes is (bufferOutIndex - bufferInIndex) - 1
+
+		bytesToRead = bufferOutIndex - bufferInIndex - 1;
+
+		if (bytesToRead > 0) {
+#ifdef WINDOWS
+			br = recv(SWTsock, (char*)sockBuffer + bufferInIndex, bytesToRead, 0);
+#else // WINDOWS
+			br = recv(SWTsock, (char*)sockBuffer + bufferInIndex, bytesToRead, MSG_DONTWAIT);
+
+			if (br < 0) {
+				if ((errno != EAGAIN) && (errno != EWOULDBLOCK)) {
+					perror("SlicFileParser::bufferSWT(): recv() error");
+				}
+			}
+#endif // WINDOWS
+
+			if (br > 0) {
+				bufferInIndex += br;
+			}
+		}
+	}
+	else if (bufferInIndex > bufferOutIndex) {
+		// empty bytes is bufferInIndex to end of buffer + bufferOutIndex - 1
+		// first read to end of buffer
+
+		if (bufferOutIndex == 0) {
+			// don't want to completely fill up tail of buffer, because can't set bufferInIndex to 0!
+
+			bytesToRead = (sizeof sockBuffer) - bufferInIndex - 1;
+		}
+		else {
+			bytesToRead = (sizeof sockBuffer) - bufferInIndex;
+		}
+
+		if (bytesToRead > 0) {
+#ifdef WINDOWS
+			br = recv(SWTsock, (char*)sockBuffer + bufferInIndex, bytesToRead, 0);
+#else // WINDOWS
+			br = recv(SWTsock, (char*)sockBuffer + bufferInIndex, bytesToRead, MSG_DONTWAIT);
+
+			if (br < 0) {
+				if ((errno != EAGAIN) && (errno != EWOULDBLOCK)) {
+					perror("SizeFileParser::bufferSWT(): recv() error");
+				}
+			}
+#endif // WINDOWS
+
+			if (br > 0) {
+				if ((bufferInIndex + br) >= (int)(sizeof sockBuffer)) {
+					bufferInIndex = 0;
+
+					bytesToRead = bufferOutIndex - 1;
+
+					if (bytesToRead > 0) {
+#ifdef WINDOWS
+						br = recv(SWTsock, (char*)sockBuffer, bytesToRead, 0);
+#else // WINDOWS
+						br = recv(SWTsock, (char*)sockBuffer, bytesToRead, MSG_DONTWAIT);
+
+						if (br < 0) {
+							if ((errno != EAGAIN) && (errno != EWOULDBLOCK)) {
+								perror("SliceFileParser::bufferSWT(): recv() error");
+							}
+						}
+#endif // WINDOWS
+						if (br > 0) {
+							bufferInIndex = br;
+						}
+					}
+				}
+				else {
+					bufferInIndex += br;
+				}
+			}
+		}
+	}
+
+#ifdef WINDOWS
+	if ((br == -1) && (WSAGetLastError() != WSAEWOULDBLOCK)) {
+		printf("Error: bufferSWT(): read socket failed\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+#else // WINDOWS
+	if ((br == -1) && ((errno != EAGAIN) && (errno != EWOULDBLOCK))) {
+		printf("Error: bufferSWT(): read socket failed\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+#endif // WINDOWS
+#endif
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::readBinaryMsg(bool& haveMsg)
+{
+	// start by stripping off end of message or end of var bytes. These would be here in the case
+	// of a wrapped buffer, or some kind of corruption
+
+	haveMsg = false;
+
+	// if doing SWT, we may have ran out of data last time before getting an entire message
+	// and pendingMsgIndex may not be 0. If not 0, pick up where we left off
+
+	if (pendingMsgIndex == 0) {
+		do {
+			if (SWTsock >= 0) {
+				//// need a buffer to read from.
+
+				//status = bufferSWT();
+
+				//if (status != TraceDqrProfiler::DQERR_OK) {
+				//	return status;
+				//}
+
+				//if (bufferInIndex == bufferOutIndex) {
+				//	return status;
+				//}
+
+				//msg[0] = sockBuffer[bufferOutIndex];
+				//bufferOutIndex += 1;
+				//if ((size_t)bufferOutIndex >= sizeof sockBuffer) {
+				//	bufferOutIndex = 0;
+				//}
+			}
+			else {
+
+                // If the queue is empty, wait till we receive new trace data
+                while (1)
+                {
+                    std::lock_guard<std::mutex> msg_queue_guard(m_msg_queue_mutex);
+                    {
+                        if (m_msg_queue.empty())
+                        {
+                            // If end of data flag is set, exit the loop
+                            std::lock_guard<std::mutex> end_of_data_guard(m_end_of_data_mutex);
+                            if (m_end_of_data == true)
+                                return TraceDqrProfiler::DQERR_EOF;
+                        }
+                        else
+                        {
+                            // We have some data in queue
+                            // Get the first byte
+                            msg[0] = m_msg_queue.front();
+                            m_msg_queue.pop_front();
+                            msgOffset++;
+                            break;
+                        }
+                    }
+                }
+
+
+				//tf.read((char*)&msg[0], sizeof msg[0]);
+				//if (!tf) {
+				//	if (tf.eof()) {
+				//		status = TraceDqrProfiler::DQERR_EOF;
+				//	}
+				//	else {
+				//		status = TraceDqrProfiler::DQERR_ERR;
+
+				//		std::cout << "Error reading trace file\n";
+				//	}
+
+				//	tf.close();
+
+				//	return status;
+				//}
+			}
+
+			if ((msg[0] == 0x00) || (((msg[0] & 0x3) != TraceDqrProfiler::MSEO_NORMAL) && (msg[0] != 0xff))) {
+				printf("Info: SliceFileParser::readBinaryMsg(): Skipping: %02x\n", msg[0]);
+			}
+		} while ((msg[0] == 0x00) || ((msg[0] & 0x3) != TraceDqrProfiler::MSEO_NORMAL));
+
+		pendingMsgIndex = 1;
+	}
+
+	//if (SWTsock >= 0) {
+	//	msgOffset = 0;
+	//}
+	//else {
+	//	msgOffset = ((uint32_t)tf.tellg()) - 1;
+
+	//}
+
+	bool done = false;
+
+	while (!done) {
+#if 0
+		if (pendingMsgIndex >= (int)(sizeof msg / sizeof msg[0])) {
+			if (SWTsock >= 0) {
+//#ifdef WINDOWS
+//				closesocket(SWTsock);
+//#else // WINDOWS
+//				close(SWTsock);
+//#endif // WINDOWS
+//				SWTsock = -1;
+			}
+			else {
+				tf.close();
+			}
+
+			std::cout << "Error: SliceFileParser::readBinaryMsg(): msg buffer overflow" << std::endl;
+
+			pendingMsgIndex = 0;
+
+			status = TraceDqrProfiler::DQERR_ERR;
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+#endif
+		if (SWTsock >= 0) {
+			status = bufferSWT();
+
+			if (status != TraceDqrProfiler::DQERR_OK) {
+				return status;
+			}
+
+			if (bufferInIndex == bufferOutIndex) {
+				return status;
+			}
+
+			msg[pendingMsgIndex] = sockBuffer[bufferOutIndex];
+
+			bufferOutIndex += 1;
+			if ((size_t)bufferOutIndex >= sizeof sockBuffer) {
+				bufferOutIndex = 0;
+			}
+		}
+		else
+        {
+            while (1)
+            {
+                std::lock_guard<std::mutex> msg_queue_guard(m_msg_queue_mutex);
+                {
+                    if (m_msg_queue.empty())
+                    {
+                        // If end of data flag is set, exit the loop
+                        std::lock_guard<std::mutex> end_of_data_guard(m_end_of_data_mutex);
+                        if (m_end_of_data == true)
+                            return TraceDqrProfiler::DQERR_EOF;
+                    }
+                    else
+                    {
+                        // We have some data in queue
+                        // Get the first byte
+                        msg[pendingMsgIndex] = m_msg_queue.front();
+                        m_msg_queue.pop_front();
+                        msgOffset++;
+                        break;
+                    }
+                }
+            }
+
+			//tf.read((char*)&msg[pendingMsgIndex], sizeof msg[0]);
+			//if (!tf) {
+			//	if (tf.eof()) {
+			//		printf("Info: SliceFileParser::readBinaryMsg(): Last message in trace file is incomplete\n");
+			//		if (profiler_globalDebugFlag) {
+			//			printf("Debug: Raw msg:");
+			//			for (int i = 0; i < pendingMsgIndex; i++) {
+			//				printf(" %02x", msg[i]);
+			//			}
+			//			printf("\n");
+			//		}
+			//		status = TraceDqrProfiler::DQERR_EOF;
+			//	}
+			//	else {
+			//		status = TraceDqrProfiler::DQERR_ERR;
+
+			//		std::cout << "Error reading trace file\n";
+			//	}
+
+			//	tf.close();
+
+				//return status;
+			//}
+		}
+
+		if ((msg[pendingMsgIndex] & 0x03) == TraceDqrProfiler::MSEO_END) {
+			done = true;
+			msgSlices = pendingMsgIndex + 1;
+		}
+
+		pendingMsgIndex += 1;
+	}
+
+	eom = false;
+	bitIndex = 0;
+
+	haveMsg = true;
+	pendingMsgIndex = 0;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::readNextByte(uint8_t* byte)
+{
+	char c;
+
+	// strip white space, comments, cr, and lf
+
+	enum {
+		STRIPPING_WHITESPACE,
+		STRIPPING_COMMENT,
+		STRIPPING_DONE
+	} ss = STRIPPING_WHITESPACE;
+
+	do {
+		tf.read((char*)&c, sizeof c);
+		if (!tf) {
+			tf.close();
+
+			status = TraceDqrProfiler::DQERR_EOF;
+
+			return TraceDqrProfiler::DQERR_EOF;
+		}
+
+		switch (ss) {
+		case STRIPPING_WHITESPACE:
+			switch (c) {
+			case '#':
+				ss = STRIPPING_COMMENT;
+				break;
+			case '\n':
+			case '\r':
+			case ' ':
+			case '\t':
+				break;
+			default:
+				ss = STRIPPING_DONE;
+			}
+			break;
+		case STRIPPING_COMMENT:
+			switch (c) {
+			case '\n':
+				ss = STRIPPING_WHITESPACE;
+				break;
+			}
+			break;
+		default:
+			break;
+		}
+	} while (ss != STRIPPING_DONE);
+
+	// now try to get two hex digits
+
+	tf.read((char*)&c, sizeof c);
+	if (!tf) {
+		tf.close();
+
+		status = TraceDqrProfiler::DQERR_EOF;
+
+		return TraceDqrProfiler::DQERR_EOF;
+	}
+
+	int hd;
+	uint8_t hn;
+
+	hd = atoh(c);
+	if (hd < 0) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	hn = hd << 4;
+
+	hd = atoh(c);
+	if (hd < 0) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	hn = hn | hd;
+
+	*byte = hn;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr SliceFileParser::readNextTraceMsg(ProfilerNexusMessage& nm, ProfilerAnalytics& analytics, bool& haveMsg)	// generator to read trace messages one at a time
+{
+	haveMsg = false;
+
+	if (status != TraceDqrProfiler::DQERR_OK) {
+		return status;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+	uint64_t   val;
+	uint8_t    tcode;
+
+	status = TraceDqrProfiler::DQERR_OK;
+
+	// read from file, store in object, compute and fill out full fields, such as address and more later
+
+	rc = readBinaryMsg(haveMsg);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+
+		// all errors from readBinaryMsg() are non-recoverable.
+
+		if (rc != TraceDqrProfiler::DQERR_EOF) {
+			std::cout << "Error: (): readNextTraceMsg() returned error " << rc << std::endl;
+		}
+
+		status = rc;
+
+		return status;
+	}
+
+	if (haveMsg == false) {
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	nm.offset = msgOffset;
+
+	int i = 0;
+
+	do {
+		nm.rawData[i] = msg[i];
+		i += 1;
+	} while (((size_t)i < sizeof nm.rawData / sizeof nm.rawData[0]) && ((msg[i - 1] & 0x03) != TraceDqrProfiler::MSEO_END));
+
+	rc = parseFixedField(6, &val);
+	if (rc == TraceDqrProfiler::DQERR_OK) {
+		tcode = (uint8_t)val;
+
+		switch (tcode) {
+		case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+			std::cout << "Unsupported debug status trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_DEVICE_ID:
+			std::cout << "Unsupported device id trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+			rc = parseOwnershipTrace(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseOwnershipTrace()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			rc = parseDirectBranch(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseDirectBranch()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			rc = parseIndirectBranch(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseIndirectBranch()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_DATA_WRITE:
+			std::cout << "unsupported data write trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_DATA_READ:
+			std::cout << "unsupported data read trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+			rc = parseDataAcquisition(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseDataAcquisition()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_ERROR:
+			rc = parseError(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseError()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_SYNC:
+			rc = parseSync(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseSync()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_CORRECTION:
+			std::cout << "Unsupported correction trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			rc = parseDirectBranchWS(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseDirectBranchWS()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			rc = parseIndirectBranchWS(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseDirectIndirectBranchWS()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+			std::cout << "unsupported data write with sync trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_DATA_READ_WS:
+			std::cout << "unsupported data read with sync trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_WATCHPOINT:
+			std::cout << "unsupported watchpoint trace message\n";
+			rc = TraceDqrProfiler::DQERR_ERR;
+			break;
+		case TraceDqrProfiler::TCODE_CORRELATION:
+			rc = parseCorrelation(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseCorrelation()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			rc = parseAuxAccessWrite(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseAuxAccessWrite()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			rc = parseIndirectHistory(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseIndirectHistory()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+			rc = parseIndirectHistoryWS(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseIndirectHisotryWS()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			rc = parseICT(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseICT()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+			rc = parseICTWS(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseICTWS()\n";
+			}
+			break;
+		case TraceDqrProfiler::TCODE_RESOURCEFULL:
+			rc = parseResourceFull(nm, analytics);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				std::cout << "Error: parseResourceFull()\n";
+			}
+			break;
+		default:
+			std::cout << "Error: readNextTraceMsg(): Unknown TCODE " << std::hex << int(tcode) << std::dec << std::endl;
+			rc = TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		std::cout << "Error possibly due to corrupted message in trace - skipping message" << std::endl;
+		if (profiler_globalDebugFlag) {
+			nm.msgNum += 1;
+			nm.dumpRawMessage();
+		}
+
+		haveMsg = false;
+	}
+
+	status = TraceDqrProfiler::DQERR_OK;
+
+	return status;
+}
+
+ProfilerObjFile::ProfilerObjFile(char* ef_name, const char* odExe)
+{
+	elfReader = nullptr;
+	//	symtab = nullptr;
+	disassembler = nullptr;
+
+	if (ef_name == nullptr) {
+		printf("Error: ProfilerObjFile::ProfilerObjFile(): null of_name argument\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return;
+	}
+
+	elfReader = new (std::nothrow) ElfReader(ef_name, odExe);
+
+	if (elfReader == nullptr) {
+		printf("Error: ProfilerObjFile::Objfile(): Could not create elfRedaer object\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	if (elfReader->getStatus() != TraceDqrProfiler::DQERR_OK) {
+		delete elfReader;
+		elfReader = nullptr;
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return;
+	}
+
+	Symtab* symtab;
+	Section* sections;
+
+	symtab = elfReader->getSymtab();
+	if (symtab == nullptr) {
+		delete elfReader;
+		elfReader = nullptr;
+
+		printf("Error: Objfile::Objfile(): Could not get symtab\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	sections = elfReader->getSections();
+	if (sections == nullptr) {
+		delete elfReader;
+		elfReader = nullptr;
+
+		printf("Error: Objfile::Objfile(): coult not get sections\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	int archSize;
+	archSize = elfReader->getArchSize();
+
+	disassembler = new (std::nothrow) Disassembler(symtab, sections, archSize);
+
+	if (disassembler == nullptr) {
+		delete elfReader;
+		elfReader = nullptr;
+
+		printf("ProfilerObjFile::ProfilerObjFile(): Coudl not create disassembler object\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	if (disassembler->getStatus() != TraceDqrProfiler::DQERR_OK) {
+		if (elfReader != nullptr) {
+			delete elfReader;
+			elfReader = nullptr;
+		}
+
+		delete disassembler;
+		disassembler = nullptr;
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return;
+	}
+
+	cutPath = nullptr;
+	newRoot = nullptr;
+
+	status = TraceDqrProfiler::DQERR_OK;
+}
+
+ProfilerObjFile::~ProfilerObjFile()
+{
+	cleanUp();
+}
+
+void ProfilerObjFile::cleanUp()
+{
+	if (cutPath != nullptr) {
+		delete[] cutPath;
+		cutPath = nullptr;
+	}
+
+	if (newRoot != nullptr) {
+		delete[] newRoot;
+		newRoot = nullptr;
+	}
+
+	if (elfReader != nullptr) {
+		delete elfReader;
+		elfReader = nullptr;
+	}
+
+	if (disassembler != nullptr) {
+		delete disassembler;
+		disassembler = nullptr;
+	}
+}
+
+TraceDqrProfiler::DQErr ProfilerObjFile::subSrcPath(const char* cutPath, const char* newRoot)
+{
+	if (this->cutPath != nullptr) {
+		delete[] this->cutPath;
+		this->cutPath = nullptr;
+	}
+
+	if (this->newRoot != nullptr) {
+		delete[] this->newRoot;
+		this->newRoot = nullptr;
+	}
+
+	if (cutPath != nullptr) {
+		int l = strlen(cutPath) + 1;
+		this->cutPath = new char[l];
+
+		strcpy(this->cutPath, cutPath);
+	}
+
+	if (newRoot != nullptr) {
+		int l = strlen(newRoot) + 1;
+		this->newRoot = new char[l];
+
+		strcpy(this->newRoot, newRoot);
+	}
+
+	if (disassembler != nullptr) {
+		TraceDqrProfiler::DQErr rc;
+
+		rc = disassembler->subSrcPath(cutPath, newRoot);
+
+		status = rc;
+		return rc;
+	}
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr ProfilerObjFile::sourceInfo(TraceDqrProfiler::ADDRESS addr, ProfilerInstruction& instInfo, ProfilerSource& srcInfo)
+{
+	TraceDqrProfiler::DQErr s;
+
+	if (disassembler == nullptr) {
+		printf("Error: ProfilerObjFile::sourceInfo(): Disassembler object null\n");
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	s = disassembler->disassemble(addr);
+	if (s != TraceDqrProfiler::DQERR_OK) {
+		status = s;
+		return s;
+	}
+
+	//	instructionInfo = disassembler->getInstructionInfo();
+	srcInfo = disassembler->getSourceInfo();
+	instInfo = disassembler->getInstructionInfo();
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ProfilerObjFile::setPathType(TraceDqrProfiler::pathType pt)
+{
+	if (disassembler != nullptr) {
+		disassembler->setPathType(pt);
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr ProfilerObjFile::parseNLSStrings(TraceDqrProfiler::nlStrings(&nlsStrings)[32])
+{
+	if (elfReader == nullptr) {
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return elfReader->parseNLSStrings(nlsStrings);
+}
+
+TraceDqrProfiler::DQErr ProfilerObjFile::dumpSyms()
+{
+	if (elfReader == nullptr) {
+		printf("elfReader is null\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return elfReader->dumpSyms();
+}
+
+Disassembler::Disassembler(Symtab* stp, Section* sp, int archsize)
+{
+	status = TraceDqrProfiler::DQERR_OK;
+
+	if (stp == nullptr) {
+		printf("Error: Disassembler::Disassembler(): stp argument is null\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	if (sp == nullptr) {
+		printf("Error: Disassembler::Disassembler(): sp argument is null\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	archSize = archsize;
+
+	pType = TraceDqrProfiler::PATH_TO_UNIX;
+
+	cachedAddr = 0;
+	cachedSecPtr = nullptr;
+	cachedIndex = -1;
+
+	symtab = stp;
+	sectionLst = sp;
+
+	fileReader = new class fileReader();
+
+	status = TraceDqrProfiler::DQERR_OK;
+}
+
+Disassembler::~Disassembler()
+{
+	// the following three pointers point to objects owned by the elfReader object, and the
+	// elfReader object will delete.
+
+	sectionLst = nullptr;
+	symtab = nullptr;
+	cachedSecPtr = nullptr;
+
+	if (fileReader != nullptr) {
+		delete fileReader;
+		fileReader = nullptr;
+	}
+}
+
+TraceDqrProfiler::DQErr Disassembler::setPathType(TraceDqrProfiler::pathType pt)
+{
+	TraceDqrProfiler::DQErr rc;
+	rc = TraceDqrProfiler::DQERR_OK;
+
+	switch (pt) {
+	case TraceDqrProfiler::PATH_TO_WINDOWS:
+		pType = TraceDqrProfiler::PATH_TO_WINDOWS;
+		break;
+	case TraceDqrProfiler::PATH_TO_UNIX:
+		pType = TraceDqrProfiler::PATH_TO_UNIX;
+		break;
+	case TraceDqrProfiler::PATH_RAW:
+		pType = TraceDqrProfiler::PATH_RAW;
+		break;
+	default:
+		pType = TraceDqrProfiler::PATH_TO_UNIX;
+		rc = TraceDqrProfiler::DQERR_ERR;
+		break;
+	}
+
+	return rc;
+}
+
+TraceDqrProfiler::DQErr Disassembler::subSrcPath(const char* cutPath, const char* newRoot)
+{
+	if (fileReader != nullptr) {
+		TraceDqrProfiler::DQErr rc;
+
+		rc = fileReader->subSrcPath(cutPath, newRoot);
+
+		status = rc;
+		return rc;
+	}
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr Disassembler::lookupInstructionByAddress(TraceDqrProfiler::ADDRESS addr, uint32_t& ins, int& insSize)
+{
+	uint32_t inst;
+	int size;
+	TraceDqrProfiler::DQErr rc;
+
+	// need to support multiple code sections and do some error checking on the address!
+
+	if (sectionLst == nullptr) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (addr != cachedAddr) {
+		TraceDqrProfiler::DQErr rc;
+
+		rc = cacheSrcInfo(addr);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return TraceDqrProfiler::DQERR_ERR;;
+		}
+	}
+
+
+	if (cachedSecPtr == nullptr) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	inst = (uint32_t)cachedSecPtr->code[cachedIndex];
+
+	rc = decodeInstructionSize(inst, size);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	insSize = size;
+
+	if (size == 16) {
+		ins = inst;
+	}
+	else {
+		ins = (((uint32_t)cachedSecPtr->code[cachedIndex + 1]) << 16) | inst;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Disassembler::decodeInstructionSize(uint32_t inst, int& inst_size)
+{
+	switch (inst & 0x0003) {
+	case 0x0000:	// quadrant 0, compressed
+		inst_size = 16;
+		return TraceDqrProfiler::DQERR_OK;
+	case 0x0001:	// quadrant 1, compressed
+		inst_size = 16;
+		return TraceDqrProfiler::DQERR_OK;
+	case 0x0002:	// quadrant 2, compressed
+		inst_size = 16;
+		return TraceDqrProfiler::DQERR_OK;
+	case 0x0003:	// not compressed. Assume RV32 for now
+		if ((inst & 0x1f) == 0x1f) {
+			fprintf(stderr, "Error: decode_instruction(): cann't decode instructions longer than 32 bits\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		inst_size = 32;
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	// error return
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+#define MOVE_BIT(bits,s,d)	(((bits)&(1<<(s)))?(1<<(d)):0)
+
+int Disassembler::decodeRV32Q0Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	// no branch or jump instruction in quadrant 0
+
+	inst_size = 16;
+	is_branch = false;
+	immediate = 0;
+
+	if ((instruction & 0x0003) != 0x0000) {
+		return 1;
+	}
+
+	// we only crare about rs1 and rd for branch instructions, so just set them to unknown for now
+	rs1 = TraceDqrProfiler::REG_unknown;
+	rd = TraceDqrProfiler::REG_unknown;
+
+	inst_type = TraceDqrProfiler::INST_UNKNOWN;
+
+	return 0;
+}
+
+int Disassembler::decodeRV32Q1Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	// Q1 compressed instruction
+
+	uint32_t t;
+
+	inst_size = 16;
+
+	switch (instruction >> 13) {
+	case 0x1:
+		inst_type = TraceDqrProfiler::INST_C_JAL;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 3, 1);
+		t |= MOVE_BIT(instruction, 4, 2);
+		t |= MOVE_BIT(instruction, 5, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 2, 5);
+		t |= MOVE_BIT(instruction, 7, 6);
+		t |= MOVE_BIT(instruction, 6, 7);
+		t |= MOVE_BIT(instruction, 9, 8);
+		t |= MOVE_BIT(instruction, 10, 9);
+		t |= MOVE_BIT(instruction, 8, 10);
+		t |= MOVE_BIT(instruction, 12, 11);
+
+		if (t & (1 << 11)) { // sign extend offset
+			t |= 0xfffff000;
+		}
+
+		immediate = t;
+
+		rs1 = TraceDqrProfiler::REG_unknown;
+		rd = TraceDqrProfiler::REG_1;
+		break;
+	case 0x5:
+		inst_type = TraceDqrProfiler::INST_C_J;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 3, 1);
+		t |= MOVE_BIT(instruction, 4, 2);
+		t |= MOVE_BIT(instruction, 5, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 2, 5);
+		t |= MOVE_BIT(instruction, 7, 6);
+		t |= MOVE_BIT(instruction, 6, 7);
+		t |= MOVE_BIT(instruction, 9, 8);
+		t |= MOVE_BIT(instruction, 10, 9);
+		t |= MOVE_BIT(instruction, 8, 10);
+		t |= MOVE_BIT(instruction, 12, 11);
+
+		if (t & (1 << 11)) { // sign extend offset
+			t |= 0xfffff000;
+		}
+
+		rs1 = TraceDqrProfiler::REG_unknown;
+		rd = TraceDqrProfiler::REG_0;
+
+		immediate = t;
+		break;
+	case 0x6:
+		inst_type = TraceDqrProfiler::INST_C_BEQZ;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 3, 1);
+		t |= MOVE_BIT(instruction, 4, 2);
+		t |= MOVE_BIT(instruction, 10, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 2, 5);
+		t |= MOVE_BIT(instruction, 5, 6);
+		t |= MOVE_BIT(instruction, 6, 7);
+		t |= MOVE_BIT(instruction, 12, 8);
+
+		if (t & (1 << 8)) { // sign extend offset
+			t |= 0xfffffe00;
+		}
+
+		rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x03);
+		rd = TraceDqrProfiler::REG_unknown;
+
+		immediate = t;
+		break;
+	case 0x7:
+		inst_type = TraceDqrProfiler::INST_C_BNEZ;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 3, 1);
+		t |= MOVE_BIT(instruction, 4, 2);
+		t |= MOVE_BIT(instruction, 10, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 2, 5);
+		t |= MOVE_BIT(instruction, 5, 6);
+		t |= MOVE_BIT(instruction, 6, 7);
+		t |= MOVE_BIT(instruction, 12, 8);
+
+		if (t & (1 << 8)) { // sign extend offset
+			t |= 0xfffffe00;
+		}
+
+		rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x03);
+		rd = TraceDqrProfiler::REG_unknown;
+
+		immediate = t;
+		break;
+	default:
+		rs1 = TraceDqrProfiler::REG_unknown;
+		rd = TraceDqrProfiler::REG_unknown;
+		inst_type = TraceDqrProfiler::INST_UNKNOWN;
+		immediate = 0;
+		is_branch = 0;
+		break;
+	}
+
+	return 0;
+}
+
+int Disassembler::decodeRV32Q2Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	// Q1 compressed instruction
+
+	inst_size = 16;
+
+	inst_type = TraceDqrProfiler::INST_UNKNOWN;
+	is_branch = false;
+	rs1 = TraceDqrProfiler::REG_unknown;
+	rd = TraceDqrProfiler::REG_unknown;
+
+	switch (instruction >> 13) {
+	case 0x4:
+		if (instruction & (1 << 12)) {
+			if ((instruction & 0x007c) == 0x0000) {
+				if ((instruction & 0x0f80) != 0x0000) {
+					inst_type = TraceDqrProfiler::INST_C_JALR;
+					is_branch = true;
+
+					rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+					rd = TraceDqrProfiler::REG_1;
+					immediate = 0;
+				}
+				else {
+					inst_type = TraceDqrProfiler::INST_C_EBREAK;
+					immediate = 0;
+					is_branch = true;
+				}
+			}
+		}
+		else {
+			if ((instruction & 0x007c) == 0x0000) {
+				if ((instruction & 0x0f80) != 0x0000) {
+					inst_type = TraceDqrProfiler::INST_C_JR;
+					is_branch = true;
+
+					rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+					rd = TraceDqrProfiler::REG_0;
+					immediate = 0;
+				}
+			}
+		}
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+int Disassembler::decodeRV32Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	if ((instruction & 0x1f) == 0x1f) {
+		fprintf(stderr, "Error: decodeBranch(): cann't decode instructions longer than 32 bits\n");
+		return 1;
+	}
+
+	uint32_t t;
+
+	inst_size = 32;
+
+	switch (instruction & 0x7f) {
+	case 0x6f:
+		inst_type = TraceDqrProfiler::INST_JAL;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 21, 1);
+		t |= MOVE_BIT(instruction, 22, 2);
+		t |= MOVE_BIT(instruction, 23, 3);
+		t |= MOVE_BIT(instruction, 24, 4);
+		t |= MOVE_BIT(instruction, 25, 5);
+		t |= MOVE_BIT(instruction, 26, 6);
+		t |= MOVE_BIT(instruction, 27, 7);
+		t |= MOVE_BIT(instruction, 28, 8);
+		t |= MOVE_BIT(instruction, 29, 9);
+		t |= MOVE_BIT(instruction, 30, 10);
+		t |= MOVE_BIT(instruction, 20, 11);
+		t |= MOVE_BIT(instruction, 12, 12);
+		t |= MOVE_BIT(instruction, 13, 13);
+		t |= MOVE_BIT(instruction, 14, 14);
+		t |= MOVE_BIT(instruction, 15, 15);
+		t |= MOVE_BIT(instruction, 16, 16);
+		t |= MOVE_BIT(instruction, 17, 17);
+		t |= MOVE_BIT(instruction, 18, 18);
+		t |= MOVE_BIT(instruction, 19, 19);
+		t |= MOVE_BIT(instruction, 31, 20);
+
+		if (t & (1 << 20)) { // sign extend offset
+			t |= 0xffe00000;
+		}
+
+		immediate = t;
+		rd = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x67:
+		if ((instruction & 0x7000) == 0x000) {
+			inst_type = TraceDqrProfiler::INST_JALR;
+			is_branch = true;
+
+			t = instruction >> 20;
+
+			if (t & (1 << 11)) { // sign extend offset
+				t |= 0xfffff000;
+			}
+
+			immediate = t;
+			rd = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+			rs1 = (TraceDqrProfiler::Reg)((instruction >> 15) & 0x1f);
+		}
+		else {
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			immediate = 0;
+			rd = TraceDqrProfiler::REG_unknown;
+			rs1 = TraceDqrProfiler::REG_unknown;
+			is_branch = false;
+		}
+		break;
+	case 0x63:
+		switch ((instruction >> 12) & 0x7) {
+		case 0x0:
+			inst_type = TraceDqrProfiler::INST_BEQ;
+			break;
+		case 0x1:
+			inst_type = TraceDqrProfiler::INST_BNE;
+			break;
+		case 0x4:
+			inst_type = TraceDqrProfiler::INST_BLT;
+			break;
+		case 0x5:
+			inst_type = TraceDqrProfiler::INST_BGE;
+			break;
+		case 0x6:
+			inst_type = TraceDqrProfiler::INST_BLTU;
+			break;
+		case 0x7:
+			inst_type = TraceDqrProfiler::INST_BGEU;
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			immediate = 0;
+			rd = TraceDqrProfiler::REG_unknown;
+			rs1 = TraceDqrProfiler::REG_unknown;
+			is_branch = false;
+			return 0;
+		}
+
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 8, 1);
+		t |= MOVE_BIT(instruction, 9, 2);
+		t |= MOVE_BIT(instruction, 10, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 25, 5);
+		t |= MOVE_BIT(instruction, 26, 6);
+		t |= MOVE_BIT(instruction, 27, 7);
+		t |= MOVE_BIT(instruction, 28, 8);
+		t |= MOVE_BIT(instruction, 29, 9);
+		t |= MOVE_BIT(instruction, 30, 10);
+		t |= MOVE_BIT(instruction, 7, 11);
+		t |= MOVE_BIT(instruction, 31, 12);
+
+		if (t & (1 << 12)) { // sign extend offset
+			t |= 0xffffe000;
+		}
+
+		immediate = t;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = (TraceDqrProfiler::Reg)((instruction >> 15) & 0x1f);
+		break;
+	case 0x73:
+		if (instruction == 0x00200073) {
+			inst_type = TraceDqrProfiler::INST_URET;
+			is_branch = true;
+			immediate = 0;
+		}
+		else if (instruction == 0x10200073) {
+			inst_type = TraceDqrProfiler::INST_SRET;
+			is_branch = true;
+			immediate = 0;
+		}
+		else if (instruction == 0x30200073) {
+			inst_type = TraceDqrProfiler::INST_MRET;
+			is_branch = true;
+			immediate = 0;
+		}
+		else if (instruction == 0x00000073) {
+			inst_type = TraceDqrProfiler::INST_ECALL;
+			immediate = 0;
+			is_branch = true;
+		}
+		else if (instruction == 0x00100073) {
+			inst_type = TraceDqrProfiler::INST_EBREAK;
+			immediate = 0;
+			is_branch = true;
+		}
+		else {
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			immediate = 0;
+			rd = TraceDqrProfiler::REG_unknown;
+			rs1 = TraceDqrProfiler::REG_unknown;
+			is_branch = false;
+		}
+		break;
+	case 0x07: // vector load
+		// Need to check width encoding field to distinguish between vector and normal FP loads (bits 12-14)
+		switch ((instruction >> 12) & 0x07) {
+		case 0x00:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+			inst_type = TraceDqrProfiler::INST_VECT_LOAD;
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			break;
+		}
+
+		is_branch = false;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x27: // vector store
+		// Need to check width encoding field to distinguish between vector and normal FP stores (bits 12-14)
+		switch ((instruction >> 12) & 0x07) {
+		case 0x00:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+			inst_type = TraceDqrProfiler::INST_VECT_STORE;
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			break;
+		}
+
+		is_branch = false;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x2f: // vector AMO
+		// Need to check width encoding field to distinguish between vector and normal AMO (bits 26-28)
+		switch ((instruction >> 12) & 0x07) {
+		case 0x00:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+			if ((instruction >> 26) & 0x01) {
+				inst_type = TraceDqrProfiler::INST_VECT_AMO_WW;
+			}
+			else {
+				inst_type = TraceDqrProfiler::INST_VECT_AMO;
+			}
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			break;
+		}
+
+		is_branch = false;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x57: // vector arith or vector config
+		if (((instruction >> 12) & 0x7) <= 6) {
+			inst_type = TraceDqrProfiler::INST_VECT_ARITH;
+		}
+		else {
+			inst_type = TraceDqrProfiler::INST_VECT_CONFIG;
+		}
+
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		is_branch = false;
+		break;
+	default:
+		inst_type = TraceDqrProfiler::INST_UNKNOWN;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		is_branch = false;
+		break;
+	}
+
+	return 0;
+}
+
+int Disassembler::decodeRV64Q0Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	// no branch or jump instruction in quadrant 0
+
+	inst_size = 16;
+	is_branch = false;
+	immediate = 0;
+
+	if ((instruction & 0x0003) != 0x0000) {
+		return 1;
+	}
+
+	// we only crare about rs1 and rd for branch instructions, so just set them to unknown for now
+	rs1 = TraceDqrProfiler::REG_unknown;
+	rd = TraceDqrProfiler::REG_unknown;
+
+	inst_type = TraceDqrProfiler::INST_UNKNOWN;
+
+	return 0;
+}
+
+int Disassembler::decodeRV64Q1Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	// Q1 compressed instruction
+
+	uint32_t t;
+
+	inst_size = 16;
+
+	switch (instruction >> 13) {
+	case 0x5:
+		inst_type = TraceDqrProfiler::INST_C_J;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 3, 1);
+		t |= MOVE_BIT(instruction, 4, 2);
+		t |= MOVE_BIT(instruction, 5, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 2, 5);
+		t |= MOVE_BIT(instruction, 7, 6);
+		t |= MOVE_BIT(instruction, 6, 7);
+		t |= MOVE_BIT(instruction, 9, 8);
+		t |= MOVE_BIT(instruction, 10, 9);
+		t |= MOVE_BIT(instruction, 8, 10);
+		t |= MOVE_BIT(instruction, 12, 11);
+
+		if (t & (1 << 11)) { // sign extend offset
+			t |= 0xfffff000;
+		}
+
+		rs1 = TraceDqrProfiler::REG_unknown;
+		rd = TraceDqrProfiler::REG_0;
+
+		immediate = t;
+		break;
+	case 0x6:
+		inst_type = TraceDqrProfiler::INST_C_BEQZ;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 3, 1);
+		t |= MOVE_BIT(instruction, 4, 2);
+		t |= MOVE_BIT(instruction, 10, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 2, 5);
+		t |= MOVE_BIT(instruction, 5, 6);
+		t |= MOVE_BIT(instruction, 6, 7);
+		t |= MOVE_BIT(instruction, 12, 8);
+
+		if (t & (1 << 8)) { // sign extend offset
+			t |= 0xfffffe00;
+		}
+
+		rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x03);
+		rd = TraceDqrProfiler::REG_unknown;
+
+		immediate = t;
+		break;
+	case 0x7:
+		inst_type = TraceDqrProfiler::INST_C_BNEZ;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 3, 1);
+		t |= MOVE_BIT(instruction, 4, 2);
+		t |= MOVE_BIT(instruction, 10, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 2, 5);
+		t |= MOVE_BIT(instruction, 5, 6);
+		t |= MOVE_BIT(instruction, 6, 7);
+		t |= MOVE_BIT(instruction, 12, 8);
+
+		if (t & (1 << 8)) { // sign extend offset
+			t |= 0xfffffe00;
+		}
+
+		rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x03);
+		rd = TraceDqrProfiler::REG_unknown;
+
+		immediate = t;
+		break;
+	default:
+		rs1 = TraceDqrProfiler::REG_unknown;
+		rd = TraceDqrProfiler::REG_unknown;
+		inst_type = TraceDqrProfiler::INST_UNKNOWN;
+		immediate = 0;
+		is_branch = 0;
+		break;
+	}
+
+	return 0;
+}
+
+int Disassembler::decodeRV64Q2Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	// Q2 compressed instruction
+
+	inst_size = 16;
+
+	inst_type = TraceDqrProfiler::INST_UNKNOWN;
+	is_branch = false;
+	rs1 = TraceDqrProfiler::REG_unknown;
+	rd = TraceDqrProfiler::REG_unknown;
+
+	switch (instruction >> 13) {
+	case 0x4:
+		if (instruction & (1 << 12)) {
+			if ((instruction & 0x007c) == 0x0000) {
+				if ((instruction & 0x0f80) != 0x0000) {
+					inst_type = TraceDqrProfiler::INST_C_JALR;
+					is_branch = true;
+
+					rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+					rd = TraceDqrProfiler::REG_1;
+					immediate = 0;
+				}
+				else {
+					inst_type = TraceDqrProfiler::INST_EBREAK;
+					immediate = 0;
+					is_branch = true;
+				}
+			}
+		}
+		else {
+			if ((instruction & 0x007c) == 0x0000) {
+				if ((instruction & 0x0f80) != 0x0000) {
+					inst_type = TraceDqrProfiler::INST_C_JR;
+					is_branch = true;
+
+					rs1 = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+					rd = TraceDqrProfiler::REG_0;
+					immediate = 0;
+				}
+			}
+		}
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+int Disassembler::decodeRV64Instruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	if ((instruction & 0x1f) == 0x1f) {
+		fprintf(stderr, "Error: decodeRV64Instruction(): cann't decode instructions longer than 32 bits\n");
+		return 1;
+	}
+
+	uint32_t t;
+
+	inst_size = 32;
+
+	switch (instruction & 0x7f) {
+	case 0x6f:
+		inst_type = TraceDqrProfiler::INST_JAL;
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 21, 1);
+		t |= MOVE_BIT(instruction, 22, 2);
+		t |= MOVE_BIT(instruction, 23, 3);
+		t |= MOVE_BIT(instruction, 24, 4);
+		t |= MOVE_BIT(instruction, 25, 5);
+		t |= MOVE_BIT(instruction, 26, 6);
+		t |= MOVE_BIT(instruction, 27, 7);
+		t |= MOVE_BIT(instruction, 28, 8);
+		t |= MOVE_BIT(instruction, 29, 9);
+		t |= MOVE_BIT(instruction, 30, 10);
+		t |= MOVE_BIT(instruction, 20, 11);
+		t |= MOVE_BIT(instruction, 12, 12);
+		t |= MOVE_BIT(instruction, 13, 13);
+		t |= MOVE_BIT(instruction, 14, 14);
+		t |= MOVE_BIT(instruction, 15, 15);
+		t |= MOVE_BIT(instruction, 16, 16);
+		t |= MOVE_BIT(instruction, 17, 17);
+		t |= MOVE_BIT(instruction, 18, 18);
+		t |= MOVE_BIT(instruction, 19, 19);
+		t |= MOVE_BIT(instruction, 31, 20);
+
+		if (t & (1 << 20)) { // sign extend offset
+			t |= 0xffe00000;
+		}
+
+		immediate = t;
+		rd = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x67:
+		if ((instruction & 0x7000) == 0x000) {
+			inst_type = TraceDqrProfiler::INST_JALR;
+			is_branch = true;
+
+			t = instruction >> 20;
+
+			if (t & (1 << 11)) { // sign extend offset
+				t |= 0xfffff000;
+			}
+
+			immediate = t;
+			rd = (TraceDqrProfiler::Reg)((instruction >> 7) & 0x1f);
+			rs1 = (TraceDqrProfiler::Reg)((instruction >> 15) & 0x1f);
+		}
+		else {
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			immediate = 0;
+			rd = TraceDqrProfiler::REG_unknown;
+			rs1 = TraceDqrProfiler::REG_unknown;
+			is_branch = false;
+		}
+		break;
+	case 0x63:
+		switch ((instruction >> 12) & 0x7) {
+		case 0x0:
+			inst_type = TraceDqrProfiler::INST_BEQ;
+			break;
+		case 0x1:
+			inst_type = TraceDqrProfiler::INST_BNE;
+			break;
+		case 0x4:
+			inst_type = TraceDqrProfiler::INST_BLT;
+			break;
+		case 0x5:
+			inst_type = TraceDqrProfiler::INST_BGE;
+			break;
+		case 0x6:
+			inst_type = TraceDqrProfiler::INST_BLTU;
+			break;
+		case 0x7:
+			inst_type = TraceDqrProfiler::INST_BGEU;
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			immediate = 0;
+			rd = TraceDqrProfiler::REG_unknown;
+			rs1 = TraceDqrProfiler::REG_unknown;
+			is_branch = false;
+			return 0;
+		}
+
+		is_branch = true;
+
+		t = MOVE_BIT(instruction, 8, 1);
+		t |= MOVE_BIT(instruction, 9, 2);
+		t |= MOVE_BIT(instruction, 10, 3);
+		t |= MOVE_BIT(instruction, 11, 4);
+		t |= MOVE_BIT(instruction, 25, 5);
+		t |= MOVE_BIT(instruction, 26, 6);
+		t |= MOVE_BIT(instruction, 27, 7);
+		t |= MOVE_BIT(instruction, 28, 8);
+		t |= MOVE_BIT(instruction, 29, 9);
+		t |= MOVE_BIT(instruction, 30, 10);
+		t |= MOVE_BIT(instruction, 7, 11);
+		t |= MOVE_BIT(instruction, 31, 12);
+
+		if (t & (1 << 12)) { // sign extend offset
+			t |= 0xffffe000;
+		}
+
+		immediate = t;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = (TraceDqrProfiler::Reg)((instruction >> 15) & 0x1f);
+		break;
+	case 0x73:
+		if (instruction == 0x00200073) {
+			inst_type = TraceDqrProfiler::INST_URET;
+			is_branch = true;
+			immediate = 0;
+		}
+		else if (instruction == 0x10200073) {
+			inst_type = TraceDqrProfiler::INST_SRET;
+			is_branch = true;
+			immediate = 0;
+		}
+		else if (instruction == 0x30200073) {
+			inst_type = TraceDqrProfiler::INST_MRET;
+			is_branch = true;
+			immediate = 0;
+		}
+		else if (instruction == 0x00000073) {
+			inst_type = TraceDqrProfiler::INST_ECALL;
+			immediate = 0;
+			is_branch = true;
+		}
+		else if (instruction == 0x00100073) {
+			inst_type = TraceDqrProfiler::INST_EBREAK;
+			immediate = 0;
+			is_branch = true;
+		}
+		else {
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			immediate = 0;
+			rd = TraceDqrProfiler::REG_unknown;
+			rs1 = TraceDqrProfiler::REG_unknown;
+			is_branch = false;
+		}
+		break;
+	case 0x07: // vector load
+		// Need to check width encoding field to distinguish between vector and normal FP loads (bits 12-14)
+		switch ((instruction >> 12) & 0x07) {
+		case 0x00:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+			inst_type = TraceDqrProfiler::INST_VECT_LOAD;
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			break;
+		}
+
+		is_branch = false;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x27: // vector store
+		// Need to check width encoding field to distinguish between vector and normal FP stores (bits 12-14)
+		switch ((instruction >> 12) & 0x07) {
+		case 0x00:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+			inst_type = TraceDqrProfiler::INST_VECT_STORE;
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			break;
+		}
+
+		is_branch = false;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x2f: // vector AMO
+		// Need to check width encoding field to distinguish between vector and normal AMO (bits 26-28)
+		switch ((instruction >> 12) & 0x07) {
+		case 0x00:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+			if ((instruction >> 26) & 0x01) {
+				inst_type = TraceDqrProfiler::INST_VECT_AMO_WW;
+			}
+			else {
+				inst_type = TraceDqrProfiler::INST_VECT_AMO;
+			}
+			break;
+		default:
+			inst_type = TraceDqrProfiler::INST_UNKNOWN;
+			break;
+		}
+
+		is_branch = false;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		break;
+	case 0x57: // vector arith or vector config
+		if (((instruction >> 12) & 0x7) <= 6) {
+			inst_type = TraceDqrProfiler::INST_VECT_ARITH;
+		}
+		else {
+			inst_type = TraceDqrProfiler::INST_VECT_CONFIG;
+		}
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		is_branch = false;
+		break;
+	default:
+		inst_type = TraceDqrProfiler::INST_UNKNOWN;
+		immediate = 0;
+		rd = TraceDqrProfiler::REG_unknown;
+		rs1 = TraceDqrProfiler::REG_unknown;
+		is_branch = false;
+		break;
+	}
+
+	return 0;
+}
+
+int Disassembler::decodeInstruction(uint32_t instruction, int archSize, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	int rc;
+
+	switch (archSize) {
+	case 32:
+		switch (instruction & 0x0003) {
+		case 0x0000:	// quadrant 0, compressed
+			rc = decodeRV32Q0Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		case 0x0001:	// quadrant 1, compressed
+			rc = decodeRV32Q1Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		case 0x0002:	// quadrant 2, compressed
+			rc = decodeRV32Q2Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		case 0x0003:	// not compressed. Assume RV32 for now
+			rc = decodeRV32Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		}
+		break;
+	case 64:
+		switch (instruction & 0x0003) {
+		case 0x0000:	// quadrant 0, compressed
+			rc = decodeRV64Q0Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		case 0x0001:	// quadrant 1, compressed
+			rc = decodeRV64Q1Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		case 0x0002:	// quadrant 2, compressed
+			rc = decodeRV64Q2Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		case 0x0003:	// not compressed. Assume RV32 for now
+			rc = decodeRV64Instruction(instruction, inst_size, inst_type, rs1, rd, immediate, is_branch);
+			break;
+		}
+		break;
+	default:
+		printf("Error: (): Unknown arch size %d\n", archSize);
+
+		rc = 1;
+	}
+
+	return rc;
+}
+
+// make all path separators either '/' or '\'; also remove '/./' and /../. Remove weird double path
+// showing up on linux
+
+void sanePath(TraceDqrProfiler::pathType pt, const char* src, char* dst)
+{
+	char drive = 0;
+	int r = 0;
+	int w = 0;
+	char sep;
+
+	if (pt == TraceDqrProfiler::PATH_RAW) {
+		strcpy(dst, src);
+
+		return;
+	}
+
+	if (pt == TraceDqrProfiler::PATH_TO_WINDOWS) {
+		sep = '\\';
+	}
+	else {
+		sep = '/';
+	}
+
+	while (src[r] != 0) {
+		switch (src[r]) {
+		case ':':
+			if (w > 0) {
+				if (((dst[w - 1] >= 'a') && (dst[w - 1] <= 'z')) || ((dst[w - 1] >= 'A') && (dst[w - 1] <= 'Z'))) {
+					drive = dst[w - 1];
+					w = 0;
+					dst[w] = drive;
+					w += 1;
+				}
+			}
+
+			dst[w] = src[r];
+			w += 1;
+			r += 1;
+			break;
+		case '/':
+		case '\\':
+			if ((w > 0) && (dst[w - 1] == sep)) {
+				// skip; remove double /
+				r += 1;
+			}
+			else {
+				dst[w] = sep;
+				w += 1;
+				r += 1;
+			}
+			break;
+		case '.':
+			if ((w > 0) && (dst[w - 1] == sep)) {
+				if ((src[r + 1] == '/') || (src[r + 1] == '\\')) { // have \.\ or /./
+					r += 2;
+				}
+				else if ((src[r + 1] == '.') && ((src[r + 2] == '/') || (src[r + 2] == '\\'))) { // have \..\ or /../
+					// scan back in w until either sep or beginning of line is found
+					w -= 1;
+					while ((w > 0) && (dst[w - 1] != sep)) {
+						w -= 1;
+					}
+					r += 3;
+				}
+				else { // have a '.' in a name - just pass it on
+					dst[w] = '.';
+					w += 1;
+					r += 1;
+				}
+			}
+			else {	// might be at beginning of string. Could be a ./ or a ../; copy the . or .. if followed by a /
+				if ((w == 0) && ((src[r + 1] == '/') || (src[r + 1] == '\\'))) {
+					// have a ./ at the beginning - strip it off
+					r += 2;
+				}
+				else {
+					dst[w] = '.';
+					w += 1;
+					r += 1;
+				}
+			}
+			break;
+		default:
+			dst[w] = src[r];
+			w += 1;
+			r += 1;
+			break;
+		}
+	}
+
+	dst[w] = 0;
+}
+
+TraceDqrProfiler::DQErr Disassembler::getFunctionName(TraceDqrProfiler::ADDRESS addr, const char*& function, int& offset)
+{
+	TraceDqrProfiler::DQErr rc;
+	Sym* sym;
+
+	function = nullptr;
+	offset = 0;
+
+	rc = symtab->lookupSymbolByAddress(addr, sym);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (sym != nullptr) {
+		function = sym->name;
+		offset = addr - sym->address;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Disassembler::findNearestLine(TraceDqrProfiler::ADDRESS addr, const char*& file, int& line)
+{
+	if (addr == 0) {
+		file = nullptr;
+		line = 0;
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	if (addr != cachedAddr) {
+		TraceDqrProfiler::DQErr rc;
+
+		rc = cacheSrcInfo(addr);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	file = cachedSecPtr->fName[cachedIndex];
+	line = cachedSecPtr->line[cachedIndex];
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Disassembler::getSrcLines(TraceDqrProfiler::ADDRESS addr, const char** filename, int* cutPathIndex, const char** functionname, unsigned int* linenumber, const char** lineptr)
+{
+	const char* file = nullptr;
+	const char* function = nullptr;
+	int line = 0;
+	int offset;
+	TraceDqrProfiler::DQErr rc;
+
+	// need to loop through all sections with code below and try to find one that succeeds
+
+	*filename = nullptr;
+	*cutPathIndex = 0;
+	*functionname = nullptr;
+	*linenumber = 0;
+	*lineptr = nullptr;
+
+	rc = findNearestLine(addr, file, line);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (file == nullptr) {
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	*linenumber = line;
+
+	rc = getFunctionName(addr, function, offset);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (file == nullptr) {
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	char fprime[2048];
+	char* sane;
+
+	if (strlen(file) > sizeof fprime) {
+		sane = new char[strlen(file) + 1];
+	}
+	else {
+		sane = fprime;
+	}
+
+	sanePath(pType, file, sane);
+
+	// the fl/filelist stuff is to get the source line text
+
+	struct fileReader::fileList* fl;
+
+	fl = fileReader->findFile(sane);
+	if (fl == nullptr) {
+		printf("Error: Disassembler::getSrcLines(): fileReader failed\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	*filename = fl->name;
+	*cutPathIndex = fl->cutPathIndex;
+
+	// save function name and line src in function list struct so it will be saved for reuse, or later use throughout the
+	// life of the object. Won't be overwritten. This is not caching.
+
+	if (function != nullptr) {
+		// find the function name in fncList
+
+		struct fileReader::funcList* funcLst;
+
+		for (funcLst = fl->funcs; (funcLst != nullptr) && (strcasecmp(funcLst->func, function) != 0); funcLst = funcLst->next) {
+			// empty
+		}
+
+		if (funcLst == nullptr) {
+			// add function to the list
+
+			int len = strlen(function) + 1;
+			char* fname = new char[len];
+			strcpy(fname, function);
+
+			funcLst = new fileReader::funcList;
+			funcLst->func = fname;
+			funcLst->next = fl->funcs;
+			fl->funcs = funcLst;
+		}
+
+		// at this point funcLst should point to this function (if it was just added or not)
+
+		*functionname = funcLst->func;
+	}
+
+	// line numbers start at 1
+
+	if ((line >= 1) && (line <= (int)fl->lineCount)) {
+		*lineptr = fl->lines[line - 1];
+	}
+
+	if (sane != fprime) {
+		delete[] sane;
+		sane = nullptr;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Disassembler::getInstruction(TraceDqrProfiler::ADDRESS addr, ProfilerInstruction& instruction)
+{
+	if (sectionLst == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;;
+	}
+
+	Section* sp = sectionLst->getSectionByAddress(addr);
+	if (sp == nullptr || sp->code == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+	int index;
+
+	index = (addr - sp->startAddr) / 2;
+
+	instruction.coreId = 0;
+	instruction.CRFlag = 0;
+	instruction.brFlags = 0;
+	instruction.address = addr;
+
+	int size;
+	uint32_t inst = sp->code[index];
+	rc = decodeInstructionSize(inst, size);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return rc;
+	}
+
+	instruction.instSize = size;
+
+	if (size > 16) {
+		inst |= sp->code[index + 1] << 16;
+	}
+
+	instruction.instruction = inst;
+	instruction.instructionText = sp->diss[index];
+
+	Sym* sym;
+
+	rc = symtab->lookupSymbolByAddress(addr, sym);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (sym != nullptr) {
+		instruction.addressLabel = sym->name;
+		instruction.addressLabelOffset = addr - sym->address;
+	}
+	else {
+		instruction.addressLabel = nullptr;
+		instruction.addressLabelOffset = 0;
+	}
+
+	instruction.timestamp = 0;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Disassembler::disassemble(TraceDqrProfiler::ADDRESS addr)
+{
+	if (sectionLst == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;;
+	}
+
+	Section* sp = sectionLst->getSectionByAddress(addr);
+	if (sp == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+	cachedInstInfo* cii;
+
+	cii = sp->getCachedInfo(addr);
+	if (cii != nullptr) {
+		printf("have cached info\n");
+
+		source.sourceFile = cii->filename;
+		source.cutPathIndex = cii->cutPathIndex;
+		source.sourceFunction = cii->functionname;
+		source.sourceLineNum = cii->linenumber;
+		source.sourceLine = cii->lineptr;
+
+		instruction.address = addr;
+		instruction.instruction = cii->instruction;
+		instruction.instSize = cii->instsize;
+		instruction.instructionText = cii->instructionText;
+
+		instruction.addressLabel = cii->addressLabel;
+		instruction.addressLabelOffset = cii->addressLabelOffset;
+
+		// instruction.timestamp = 0;
+		// instruction.cycles = 0;
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	rc = getInstruction(addr, instruction);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	//rc = getSrcLines(addr, &source.sourceFile, &source.cutPathIndex, &source.sourceFunction, &source.sourceLineNum, &source.sourceLine);
+	//if (rc != TraceDqrProfiler::DQERR_OK) {
+	//	return TraceDqrProfiler::DQERR_ERR;
+	//}
+
+	sp->setCachedInfo(addr, source.sourceFile, source.cutPathIndex, source.sourceFunction, source.sourceLineNum, source.sourceLine, instruction.instructionText, instruction.instruction, instruction.instSize, instruction.addressLabel, instruction.addressLabelOffset);
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr Disassembler::cacheSrcInfo(TraceDqrProfiler::ADDRESS addr)
+{
+	if (sectionLst == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	Section* sp = sectionLst->getSectionByAddress(addr);
+	if (sp == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	cachedAddr = addr;
+	cachedSecPtr = sp;
+	cachedIndex = (addr - sp->startAddr) / 2;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+AddrStack::AddrStack(int size)
+{
+	stackSize = size;
+	sp = size;
+
+	if (size == 0) {
+		stack = nullptr;
+	}
+	else {
+		stack = new TraceDqrProfiler::ADDRESS[size];
+	}
+}
+
+AddrStack::~AddrStack()
+{
+	if (stack != nullptr) {
+		delete[] stack;
+		stack = nullptr;
+	}
+
+	stackSize = 0;
+	sp = 0;
+}
+
+void AddrStack::reset()
+{
+	sp = stackSize;
+}
+
+int AddrStack::push(TraceDqrProfiler::ADDRESS addr)
+{
+	if (sp <= 0) {
+		return 1;
+	}
+
+	sp -= 1;
+	stack[sp] = addr;
+
+	return 0;
+}
+
+TraceDqrProfiler::ADDRESS AddrStack::pop()
+{
+	if (sp >= stackSize) {
+		return -1;
+	}
+
+	TraceDqrProfiler::ADDRESS t = stack[sp];
+	sp += 1;
+
+	return t;
+}

--- a/src/dqr_profiler_interface.cpp
+++ b/src/dqr_profiler_interface.cpp
@@ -1,0 +1,424 @@
+/******************************************************************************
+	   Module: dqr_interface.cpp
+	 Engineer: Arjun Suresh
+  Description: Implementation for Sifive TraceProfiler Decoder Interface
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+******************************************************************************/
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cstring>
+#include <cstdint>
+#include <thread>
+#include <string>
+#ifndef __linux__
+#include <WinSock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+#include "SocketIntf.h"
+#include "dqr_profiler_interface.h"
+#include "PacketFormat.h"
+
+#ifdef __linux__
+
+#define TYP_INIT 0 
+#define TYP_SMLE 1 
+#define TYP_BIGE 2 
+
+uint64_t htonll(uint64_t src);
+
+/****************************************************************************
+     Function: htonll
+     Engineer: Arjun Suresh
+        Input: src - Host byte order value
+       Output: None
+       return: uint64_t - Value in host byte order
+  Description: Converts host to network byte order for 64bit variables
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+****************************************************************************/
+uint64_t htonll(uint64_t src)
+{
+    static int typ = TYP_INIT;
+    unsigned char c;
+    union {
+        unsigned long long ull;
+        unsigned char c[8];
+    } x;
+    if (typ == TYP_INIT)
+    {
+        x.ull = 0x01;
+        typ = (x.c[7] == 0x01ULL) ? TYP_BIGE : TYP_SMLE;
+    }
+    if (typ == TYP_BIGE)
+        return src;
+    x.ull = src;
+    c = x.c[0]; x.c[0] = x.c[7]; x.c[7] = c;
+    c = x.c[1]; x.c[1] = x.c[6]; x.c[6] = c;
+    c = x.c[2]; x.c[2] = x.c[5]; x.c[5] = c;
+    c = x.c[3]; x.c[3] = x.c[4]; x.c[4] = c;
+    return x.ull;
+}
+#endif
+
+/****************************************************************************
+     Function: StartProfilingThread
+     Engineer: Arjun Suresh
+        Input: thread_idx - Index of the thread. There can be multiple threads 
+                            to parallel process data. Thread idx is required
+                            by the server side to reconstruct the data in
+                            correct order
+       Output: None
+       return: TySifiveTraceProfileError
+  Description: Starts the profiling thread to process the trace data to generate
+               the PC samples
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+****************************************************************************/
+TySifiveTraceProfileError SifiveProfilerInterface::StartProfilingThread(uint32_t thread_idx)
+{
+    trace = new (std::nothrow) TraceProfiler(tf_name, ef_name, numAddrBits, addrDispFlags, srcbits, od_name, freq);
+    if (trace == nullptr)
+    {
+        printf("Error: Could not create TraceProfiler object\n");
+        CleanUp();
+        return SIFIVE_TRACE_PROFILER_MEM_CREATE_ERR;
+    }
+
+    if (trace->getStatus() != TraceDqrProfiler::DQERR_OK)
+    {
+        printf("Error: new TraceProfiler(%s,%s) failed\n", tf_name, ef_name);
+        CleanUp();
+        return SIFIVE_TRACE_PROFILER_TRACE_STATUS_ERROR;
+    }
+
+    trace->setTraceType(traceType);
+    trace->setTSSize(tssize);
+    trace->setPathType(pt);
+
+    m_thread_idx = thread_idx;
+
+#if TRANSFER_DATA_OVER_SOCKET == 1
+    m_client = new SocketIntf(m_port_no);
+    if (m_client->open() != 0)
+        return SIFIVE_TRACE_PROFILER_ERR;
+    // Send the packet
+    PICP msg(32, PICP_TYPE_INTERNAL, PICP_CMD_BULK_WRITE);
+    uint32_t temp = htonl(thread_idx);
+    msg.AttachData(reinterpret_cast<uint8_t *>(&temp), sizeof(temp));
+    uint32_t maxSize = 0;
+    uint8_t *msgPacket = msg.GetPacketToSend(&maxSize);
+    m_client->write(msgPacket, maxSize);
+    WaitforACK();
+#endif
+
+    mp_buffer = new uint64_t[PROFILE_THREAD_BUFFER_SIZE];
+    if (mp_buffer == nullptr)
+    {
+        CleanUp();
+        return SIFIVE_TRACE_PROFILER_MEM_CREATE_ERR;
+    }
+
+    try
+    { 
+        m_profiling_thread = std::thread(&SifiveProfilerInterface::ProfilingThread, this);
+    }
+    catch (...)
+    {
+        return SIFIVE_TRACE_PROFILER_ERR;
+    }
+
+    return SIFIVE_TRACE_PROFILER_OK;
+}
+
+/****************************************************************************
+     Function: SetEndOfData
+     Engineer: Arjun Suresh
+        Input: None
+       Output: None
+       return: None
+  Description: Marks the end of trace data. If this is not called the profiling
+               thread will not exit as it will be waiting for more data.
+               Expected to be called at the end of a trace fetch.
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+****************************************************************************/
+void SifiveProfilerInterface::SetEndOfData()
+{
+    trace->SetEndOfData();
+}
+
+/****************************************************************************
+     Function: PushTraceData
+     Engineer: Arjun Suresh
+        Input: p_buff - Pointer to buffer that contains the trace data
+               size - Size in bytes of the trace data
+       Output: None
+       return: TySifiveTraceProfileError
+  Description: Pushes the trace data for processing
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+****************************************************************************/
+TySifiveTraceProfileError SifiveProfilerInterface::PushTraceData(uint8_t *p_buff, const uint64_t& size)
+{
+    return (trace->PushTraceData(p_buff, size) == TraceDqrProfiler::DQERR_OK) ? SIFIVE_TRACE_PROFILER_OK : SIFIVE_TRACE_PROFILER_ERR;
+}
+
+/****************************************************************************
+     Function: WaitForProfilerCompletion
+     Engineer: Arjun Suresh
+        Input: None
+       Output: None
+       return: None
+  Description: Waits till the profilng thread completes. For each thread 
+               there will be a seperate profiler interface instance, so
+               thread idx is not required here.
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+****************************************************************************/
+void SifiveProfilerInterface::WaitForProfilerCompletion()
+{
+    if (m_profiling_thread.joinable())
+        m_profiling_thread.join();
+    CleanUp();
+}
+
+/****************************************************************************
+     Function: ProfilingThread
+     Engineer: Arjun Suresh
+        Input: None
+       Output: None
+       return: TySifiveTraceProfileError
+  Description: The profiling thread functions that generates the PC sample
+               data and send the data over socket.
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+****************************************************************************/
+TySifiveTraceProfileError SifiveProfilerInterface::ProfilingThread()
+{
+    uint64_t address_out = 0;
+    uint64_t prev_addr = 0;
+    uint64_t idx = 0;
+    uint64_t total_bytes_sent = 0;
+    uint32_t mp_buffer_size_bytes = (PROFILE_THREAD_BUFFER_SIZE * sizeof(mp_buffer[0]));
+    ProfilerInstruction *instInfo = nullptr;
+
+#if WRITE_SEND_DATA_TO_FILE == 1
+    std::string file_path = std::string(SEND_DATA_FILE_DUMP_PATH) + to_string(m_thread_idx) + ".txt";
+    FILE *fp = fopen(file_path.c_str(), "wb");
+#endif
+
+    // Send the packet
+    while (trace->NextInstruction(&instInfo, address_out) == TraceDqrProfiler::DQERR_OK)
+    {
+        if (idx >= PROFILE_THREAD_BUFFER_SIZE)
+        {
+#if TRANSFER_DATA_OVER_SOCKET == 1
+            // Send the packet
+            PICP msg(32, PICP_TYPE_INTERNAL, PICP_CMD_BULK_WRITE);
+            uint32_t temp = htonl(mp_buffer_size_bytes);
+            msg.AttachData(reinterpret_cast<uint8_t *>(&temp), sizeof(temp));
+            uint32_t maxSize = 0;
+            uint8_t *msgPacket = msg.GetPacketToSend(&maxSize);
+
+           // printf("\nSending Header Thread ID %d", m_thread_idx);
+            total_bytes_sent += m_client->write(msgPacket, maxSize);
+
+           // printf("\nWaiting for Header ACK Thread ID %d", m_thread_idx);
+            WaitforACK();
+           // printf("\nReceived Header ACK Thread ID %d", m_thread_idx);
+
+            //printf("\nSending Data Thread ID %d", m_thread_idx);
+            total_bytes_sent += m_client->write((uint8_t *)mp_buffer, mp_buffer_size_bytes);
+
+           // printf("\nWaiting for Data ACK Thread ID %d", m_thread_idx);
+            WaitforACK();
+           // printf("\nReceived Data ACK Thread ID %d", m_thread_idx);
+            //printf("+");
+#endif
+            idx = 0;
+        }
+        if (address_out != prev_addr)
+        {
+#if WRITE_SEND_DATA_TO_FILE == 1
+            fprintf(fp, "%llx\n", address_out);
+#endif
+            mp_buffer[idx++] = htonll(address_out);
+            prev_addr = address_out;
+        }
+    }
+
+    if (idx > 0)
+    {
+#if TRANSFER_DATA_OVER_SOCKET == 1
+        // Send the packet
+        uint32_t size_to_send = (idx * sizeof(mp_buffer[0]));
+        PICP msg(32, PICP_TYPE_INTERNAL, PICP_CMD_BULK_WRITE);
+        uint32_t temp = htonl(size_to_send);
+        msg.AttachData(reinterpret_cast<uint8_t *>(&temp), sizeof(temp));
+        uint32_t maxSize = 0;
+        uint8_t *msgPacket = msg.GetPacketToSend(&maxSize);
+        //printf("\n-Sending Header Thread ID %d", m_thread_idx);
+        total_bytes_sent += m_client->write(msgPacket, maxSize);
+
+       // printf("\n-Waiting for Header ACK Thread ID %d", m_thread_idx);
+        WaitforACK();
+        //printf("\n-Received Header ACK Thread ID %d", m_thread_idx);
+
+
+       // printf("\n-Sending Data Thread ID %d", m_thread_idx);
+       total_bytes_sent += m_client->write((uint8_t *) mp_buffer, size_to_send);
+       printf("\n-Total Bytes Sent : %llu", total_bytes_sent);
+
+       // printf("\n-Waiting for Data ACK Thread ID %d", m_thread_idx);
+        WaitforACK();
+       // printf("\n-Received Data ACK Thread ID %d", m_thread_idx);
+#endif
+    }
+
+#if WRITE_SEND_DATA_TO_FILE == 1
+    fclose(fp);
+#endif
+
+#if TRANSFER_DATA_OVER_SOCKET == 1
+    if (m_client)
+    {
+        m_client->close();
+        delete m_client;
+        m_client = nullptr;
+    }
+#endif
+    return SIFIVE_TRACE_PROFILER_OK;
+}
+
+/****************************************************************************
+     Function: WaitforACK
+     Engineer: Arjun Suresh
+        Input: None
+       Output: None
+       return: None
+  Description: Waits till the UI sends an ACK packet
+  Date         Initials    Description
+  26-Apr-2024  AS          Initial
+****************************************************************************/
+void SifiveProfilerInterface::WaitforACK()
+{
+    uint32_t maxSize = 64;
+    uint8_t buff[64] = { 0 };
+    int32_t recvSize = m_client->read(buff, &maxSize);
+    if (recvSize < static_cast<int>(PICP::GetMinimumSize()))
+    {
+        printf("\nSocket Error");
+    }
+    else
+    {
+        PICP retPacket(buff, maxSize);
+        if (retPacket.Validate())
+        {
+            if (PICP_TYPE_RESPONSE == retPacket.GetType())
+            {
+                if (retPacket.GetResponse() != 0xDEADBEEF)
+                {
+                    printf("\nCRC Failed");
+                }
+            }
+        }
+    }
+}
+
+/****************************************************************************
+	 Function: CleanUp
+	 Engineer: Arjun Suresh
+		Input: None
+	   Output: None
+	   return: None
+  Description: CleanUp Function
+  Date         Initials    Description
+2-Nov-2022     AS          Initial
+****************************************************************************/
+void SifiveProfilerInterface::CleanUp()
+{
+#if TRANSFER_DATA_OVER_SOCKET == 1
+    if (m_client)
+    {
+        m_client->close();
+        delete m_client;
+        m_client = nullptr;
+    }
+#endif
+    if (mp_buffer)
+    {
+        delete[] mp_buffer;
+        mp_buffer = nullptr;
+    }
+	if (fp != nullptr)
+	{
+		fclose(fp);
+		fp = nullptr;
+	}
+	if (trace != nullptr) {
+		trace->cleanUp();
+
+		delete trace;
+		trace = nullptr;
+	}
+}
+
+/****************************************************************************
+	 Function: Configure
+	 Engineer: Arjun Suresh
+		Input: config - Decoder config structure
+	   Output: None
+	   return: TySifiveTraceProfileError
+  Description: Function to configure the decoder
+  Date         Initials    Description
+2-Nov-2022     AS          Initial
+****************************************************************************/
+TySifiveTraceProfileError SifiveProfilerInterface::Configure(const TProfilerConfig& config)
+{
+	tf_name = config.trace_filepath;
+	ef_name = config.elf_filepath;
+	od_name = config.objdump_path;
+	src_flag = config.display_src_info;
+	file_flag = config.display_file_info;
+	dasm_flag = config.display_dissassembly_info;
+	trace_flag = config.display_trace_msg;
+	func_flag = config.display_function_info;
+	showCallsReturns = config.display_call_return_info;
+	showBranches = config.display_branches_info;
+	profiler_globalDebugFlag = config.display_raw_message_info;
+	ctf_flag = config.enable_common_trace_format;
+	profile_flag = config.enable_profiling_format;
+	analytics_detail = config.analytics_detail_log_level;
+	caType = config.cycle_accuracte_type;
+	traceType = config.trace_type;
+	numAddrBits = config.numAddrBits;
+	addrDispFlags = config.addrDispFlags;
+	archSize = config.archSize;
+	msgLevel = config.trace_msg_log_level;
+	tssize = config.timestamp_counter_size_in_bits;
+	freq = config.timestamp_tick_clk_freq_hz;
+	srcbits = config.src_field_size_bits;
+	itcPrintOpts = config.itc_print_options;
+	itcPrintChannel = config.itc_print_channel;
+    m_port_no = config.portno;
+
+	return SIFIVE_TRACE_PROFILER_OK;
+}
+
+/****************************************************************************
+	 Function: GetSifiveProfilerInterface
+	 Engineer: Arjun Suresh
+		Input: None
+	   Output: None
+	   return: The pointer to the interface class object
+  Description: Function that creates the interface class object
+  Date         Initials    Description
+2-Nov-2022     AS          Initial
+****************************************************************************/
+SifiveProfilerInterface* GetSifiveProfilerInterface()
+{
+	return new SifiveProfilerInterface;
+}

--- a/src/dqr_trace_profiler.cpp
+++ b/src/dqr_trace_profiler.cpp
@@ -1,0 +1,7444 @@
+/* Copyright 2022 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cstring>
+#include <cstdint>
+#include <time.h>
+#include <sys/stat.h>
+#ifdef WINDOWS
+#include <winsock2.h>
+#else // WINDOWS
+//#include <unistd.h>
+#endif // WINDOWS
+
+#include "dqr_profiler.h"
+#include "dqr_trace_profiler.h"
+
+int32_t ichar_equals(char a, char b)
+{
+	return std::tolower(static_cast<unsigned char>(a)) ==
+		std::tolower(static_cast<unsigned char>(b));
+}
+
+int32_t strcasecmp(const std::string& a, const std::string& b)
+{
+	if (a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), ichar_equals))
+	{
+		return 0;
+	}
+	return -1;
+}
+
+
+#ifdef DO_TIMES
+Timer::Timer()
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+
+	startTime = ts.tv_sec + (ts.tv_nsec / 1000000000.0);
+}
+
+Timer::~Timer()
+{
+}
+
+double Timer::start()
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+
+	startTime = ts.tv_sec + (ts.tv_nsec / 1000000000.0);
+
+	return startTime;
+}
+
+double Timer::etime()
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+
+	double t = ts.tv_sec + (ts.tv_nsec / 1000000000.0);
+
+	return t - startTime;
+}
+#endif // DO_TIMES
+
+// class ProfilerCATrace methods
+
+ProfilerCATraceRec::ProfilerCATraceRec()
+{
+	offset = 0;
+	address = 0;
+}
+
+void ProfilerCATraceRec::dump()
+{
+	printf("0x%08x\n", (uint32_t)address);
+	for (int i = 0; (size_t)i < sizeof data / sizeof data[0]; i++) {
+		printf("%3d  ", (i * 30) >> 1);
+
+		for (int j = 28; j >= 0; j -= 2) {
+			if (j != 28) {
+				printf(":");
+			}
+			printf("%01x", (data[i] >> j) & 0x3);
+		}
+
+		printf("\n");
+	}
+}
+
+void ProfilerCATraceRec::dumpWithCycle()
+{
+	printf("0x%08x\n", (uint32_t)address);
+	for (int i = 0; (size_t)i < sizeof data / sizeof data[0]; i++) {
+		for (int j = 28; j >= 0; j -= 2) {
+			printf("%d %01x\n", (i * 30 + (28 - j)) >> 1, (data[i] >> j) & 0x3);
+		}
+	}
+}
+
+int ProfilerCATraceRec::consumeCAVector(uint32_t& record, uint32_t& cycles)
+{
+	int dataIndex;
+
+	// check if we have exhausted all bits in this record
+
+	// for vectors, offset and dataIndex are the array index for data[]
+
+	dataIndex = offset;
+
+	while (((size_t)dataIndex <= sizeof data / sizeof data[0]) && ((data[dataIndex] & 0x3fffffff) == 0)) {
+		dataIndex += 1;
+	}
+
+	if ((size_t)dataIndex >= sizeof data / sizeof data[0]) {
+		// out of records in the trace record. Signal caller to get more records
+
+		record = 0;
+		cycles = 0;
+
+		return 0;
+	}
+
+	record = data[dataIndex];
+	offset = dataIndex + 1;
+
+	// cycle is the start cycle of the record returned relative to the start of the 32 word block.
+	// The record represents 5 cycles (5 cycles in each 32 bit record)
+
+	cycles = dataIndex * 5;
+
+	return 1;
+}
+
+int ProfilerCATraceRec::consumeCAInstruction(uint32_t& pipe, uint32_t& cycles)
+{
+	int dataIndex;
+	int bitIndex;
+	bool found = false;
+
+	// this function looks for pipe finish bits in an instruction trace (non-vector trace)
+
+	// check if we have exhausted all bits in this record
+
+//	printf("ProfilerCATraceRec::consumCAInstruction(): offset: %d\n",offset);
+
+	if (offset >= 30 * 32) {
+		// this record is exhausted. Tell caller to read another record
+
+		return 0;
+	}
+
+	// find next non-zero bit field
+
+	dataIndex = offset / 30; // 30 bits of data in each data word. dataIndex is data[] index
+	bitIndex = 29 - (offset % 30);  // 0 - 29 is the bit index to start looking at (29 oldest, 0 newest)
+
+	//	for (int i = 0; i < 32; i++) {
+	//		printf("data[%d]: %08x\n",i,data[i]);
+	//	}
+
+	while (found == false) {
+		while ((bitIndex >= 0) && ((data[dataIndex] & (1 << bitIndex)) == 0)) {
+			bitIndex -= 1;
+			offset += 1;
+		}
+
+		if (bitIndex < 0) {
+			// didn't find any 1s in data[dataIndex]. Check next data item
+			dataIndex += 1;
+
+			if ((size_t)dataIndex >= sizeof data / sizeof data[0]) {
+				return 0; // failure
+			}
+
+			bitIndex = 29;
+		}
+		else {
+			// found a one
+
+			// cycle is the start cycle of the pipe bit relative to the start of the 32 word block.
+
+//			cycles = dataIndex * 15 + (29-bitIndex)/2;
+//			or:
+			cycles = offset / 2;
+
+			//			printf("one at offset: %d, dataIndex: %d, bitindex: %d, cycle: %d\n",offset,dataIndex,bitIndex,cycles);
+
+						// Bump past it
+			offset += 1;
+			found = true;
+		}
+	}
+
+	if (bitIndex & 0x01) {
+		pipe = TraceDqrProfiler::CAFLAG_PIPE0;
+	}
+	else {
+		pipe = TraceDqrProfiler::CAFLAG_PIPE1;
+	}
+
+	//	printf("ProfilerCATraceRec::consumeCAInstruction(): Found: offset: %d cycles: %d\n",offset,cycles);
+
+	return 1;	// success
+}
+
+ProfilerCATrace::ProfilerCATrace(char* caf_name, TraceDqrProfiler::CATraceType catype)
+{
+	caBufferSize = 0;
+	caBuffer = nullptr;
+	caBufferIndex = 0;
+	blockRecNum = 0;
+
+	status = TraceDqrProfiler::DQERR_OK;
+
+	if (caf_name == nullptr) {
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	std::ifstream catf;
+
+	catf.open(caf_name, std::ios::in | std::ios::binary);
+
+	if (!catf) {
+		printf("Error: ProfilerCATrace::ProfilerCATrace(): could not open cycle accurate trace file %s for input\n", caf_name);
+		status = TraceDqrProfiler::DQERR_OPEN;
+		return;
+	}
+
+	catf.seekg(0, catf.end);
+	caBufferSize = catf.tellg();
+	catf.seekg(0, catf.beg);
+
+	caBuffer = new uint8_t[caBufferSize];
+
+	catf.read((char*)caBuffer, caBufferSize);
+
+	catf.close();
+
+	//	printf("caBufferSize: %d\n",caBufferSize);
+	//
+	//	int *ip;
+	//	ip = (int*)caBuffer;
+	//
+	//	for (int i = 0; (size_t)i < caBufferSize / sizeof(int); i++) {
+	//		printf("%3d  ",(i*30)>>1);
+	//
+	//		for (int j = 28; j >= 0; j -= 2) {
+	//			if (j != 28) {
+	//				printf(":");
+	//			}
+	//			printf("%01x",(ip[i] >> j) & 0x3);
+	//		}
+	//
+	//		printf("\n");
+	//	}
+
+	traceQOut = 0;
+	traceQIn = 0;
+
+	caType = catype;
+
+	switch (catype) {
+	case TraceDqrProfiler::CATRACE_VECTOR:
+		traceQSize = 512;
+		caTraceQ = new CATraceQItem[traceQSize];
+		break;
+	case TraceDqrProfiler::CATRACE_INSTRUCTION:
+		traceQSize = 0;
+		caTraceQ = nullptr;
+		break;
+	case TraceDqrProfiler::CATRACE_NONE:
+		traceQSize = 0;
+		caTraceQ = nullptr;
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		printf("Error: ProfilerCATrace::ProfilerCATrace(): invalid trace type CATRACE_NONE\n");
+		return;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+
+	rc = parseNextCATraceRec(catr);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: ProfilerCATrace::ProfilerCATrace(): Error parsing first CA trace record\n");
+		status = rc;
+	}
+	else {
+		status = TraceDqrProfiler::DQERR_OK;
+	}
+
+	startAddr = catr.address;
+};
+
+ProfilerCATrace::~ProfilerCATrace()
+{
+	if (caBuffer != nullptr) {
+		delete[] caBuffer;
+		caBuffer = nullptr;
+	}
+
+	caBufferSize = 0;
+	caBufferIndex = 0;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::rewind()
+{
+	TraceDqrProfiler::DQErr rc;
+
+	// this function needs to work for both CA instruction and CA Vector
+
+	caBufferIndex = 0;
+
+	catr.offset = 0;
+	catr.address = 0;
+
+	rc = parseNextCATraceRec(catr);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: ProfilerCATrace::rewind(): Error parsing first CA trace record\n");
+		status = rc;
+	}
+	else {
+		status = TraceDqrProfiler::DQERR_OK;
+	}
+
+	startAddr = catr.address;
+
+	traceQOut = 0;
+	traceQIn = 0;
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::dumpCurrentCARecord(int level)
+{
+	switch (level) {
+	case 0:
+		catr.dump();
+		break;
+	case 1:
+		catr.dumpWithCycle();
+		break;
+	default:
+		printf("Error: ProfilerCATrace::dumpCurrentCARecord(): invalid level %d\n", level);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::packQ()
+{
+	int src;
+	int dst;
+
+	dst = traceQOut;
+	src = traceQOut;
+
+	while ((dst != traceQIn) && (src != traceQIn)) { // still have stuff in Q
+		// find next empty record
+
+		while ((dst != traceQIn) && (caTraceQ[dst].record != 0)) {
+			// look for an empty slot
+
+			dst += 1;
+			if (dst >= traceQSize) {
+				dst = 0;
+			}
+		}
+
+		if (dst != traceQIn) {
+			// dst is an empty slot
+
+			// now find next valid record
+
+			src = dst + 1;
+			if (src >= traceQSize) {
+				src = 0;
+			}
+
+			while ((src != traceQIn) && (caTraceQ[src].record == 0)) {
+				// look for a record with data in it to move
+
+				src += 1;
+				if (src >= traceQSize) {
+					src = 0;
+				}
+			}
+
+			if (src != traceQIn) {
+				caTraceQ[dst] = caTraceQ[src];
+				caTraceQ[src].record = 0; // don't forget to mark this record as empty!
+
+				// zero out the q depth stats fields
+
+				caTraceQ[src].qDepth = 0;
+				caTraceQ[src].arithInProcess = 0;
+				caTraceQ[src].loadInProcess = 0;
+				caTraceQ[src].storeInProcess = 0;
+			}
+		}
+	}
+
+	// dst either points to traceQIn, or the last full record
+
+	if (dst != traceQIn) {
+		// update traceQin
+
+		dst += 1;
+		if (dst >= traceQSize) {
+			dst = 0;
+		}
+		traceQIn = dst;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+int ProfilerCATrace::roomQ()
+{
+	if (traceQIn == traceQOut) {
+		return traceQSize - 1;
+	}
+
+	if (traceQIn < traceQOut) {
+		return traceQOut - traceQIn - 1;
+	}
+
+	return traceQSize - traceQIn + traceQOut - 1;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::addQ(uint32_t data, uint32_t t)
+{
+	// first see if there is enough room in the Q for 5 new entries
+
+	int r;
+
+	r = roomQ();
+
+	if (r < 5) {
+		TraceDqrProfiler::DQErr rc;
+
+		rc = packQ();
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			return rc;
+		}
+
+		r = roomQ();
+		if (r < 5) {
+			printf("Error: addQ(): caTraceQ[] full\n");
+
+			dumpCAQ();
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	for (int i = 0; i < 5; i++) {
+		uint8_t rec;
+
+		rec = (uint8_t)(data >> (6 * (4 - i))) & 0x3f;
+		if (rec != 0) {
+			caTraceQ[traceQIn].record = rec;
+			caTraceQ[traceQIn].cycle = t;
+
+			// zero out the q depth stats fields
+
+			caTraceQ[traceQIn].qDepth = 0;
+			caTraceQ[traceQIn].arithInProcess = 0;
+			caTraceQ[traceQIn].loadInProcess = 0;
+			caTraceQ[traceQIn].storeInProcess = 0;
+
+			traceQIn += 1;
+			if (traceQIn >= traceQSize) {
+				traceQIn = 0;
+			}
+		}
+
+		t += 1;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::parseNextVectorRecord(int& newDataStart)
+{
+	uint32_t cycles;
+	uint32_t record;
+	TraceDqrProfiler::DQErr rc;
+
+	// get another CA Vector record (32 bits) from the catr object and add to traceQ
+
+	int numConsumed;
+	numConsumed = 0;
+
+	while (numConsumed == 0) {
+		numConsumed = catr.consumeCAVector(record, cycles);
+		if (numConsumed == 0) {
+			// need to read another record
+
+			rc = parseNextCATraceRec(catr); // this will reload catr.data[]
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+		}
+	}
+
+	newDataStart = traceQIn;
+
+	cycles += blockRecNum * 5 * 32;
+
+	rc = addQ(record, cycles);
+
+	status = rc;
+
+	return rc;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::consumeCAInstruction(uint32_t& pipe, uint32_t& cycles)
+{
+	// Consume next pipe flag. Reloads catr.data[] from caBuffer if needed
+
+	int numConsumed;
+	numConsumed = 0;
+
+	TraceDqrProfiler::DQErr rc;
+
+	//	printf("ProfilerCATrace::consumeCAInstruction()\n");
+
+	while (numConsumed == 0) {
+		numConsumed = catr.consumeCAInstruction(pipe, cycles);
+		//		printf("ProfilerCATrace::consumeCAInstruction(): num consumed: %d\n",numConsumed);
+
+		if (numConsumed == 0) {
+			// need to read another record
+
+			rc = parseNextCATraceRec(catr);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+		}
+	}
+
+	cycles += blockRecNum * 15 * 32;
+
+	//	printf("ProfilerCATrace::consumeCAInstruction(): cycles: %d\n",cycles);
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::consumeCAPipe(int& QStart, uint32_t& cycles, uint32_t& pipe)
+{
+	if (caTraceQ == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// first look for pipe info in Q
+
+	// look in Q and see if record with matching type is found
+
+	while (QStart != traceQIn) {
+		if ((caTraceQ[QStart].record & TraceDqrProfiler::CAVFLAG_V0) != 0) {
+			pipe = TraceDqrProfiler::CAFLAG_PIPE0;
+			cycles = caTraceQ[QStart].cycle;
+			caTraceQ[QStart].record &= ~TraceDqrProfiler::CAVFLAG_V0;
+
+			//			QStart += 1;
+			//			if (QStart >= traceQSize) {
+			//				QStart = 0;
+			//			}
+
+			return TraceDqrProfiler::DQERR_OK;
+		}
+
+		if ((caTraceQ[QStart].record & TraceDqrProfiler::CAVFLAG_V1) != 0) {
+			pipe = TraceDqrProfiler::CAFLAG_PIPE1;
+			cycles = caTraceQ[QStart].cycle;
+			caTraceQ[QStart].record &= ~TraceDqrProfiler::CAVFLAG_V1;
+
+			//			QStart += 1;
+			//			if (QStart >= traceQSize) {
+			//				QStart = 0;
+			//			}
+
+			return TraceDqrProfiler::DQERR_OK;
+		}
+
+		QStart += 1;
+
+		if (QStart >= traceQSize) {
+			QStart = 0;
+		}
+	}
+
+	// otherwise, start reading records and adding them to the Q until
+	// matching type is found
+
+	TraceDqrProfiler::DQErr rc;
+
+	for (;;) {
+		// get next record
+
+		rc = parseNextVectorRecord(QStart);	// reads a record and adds it to the Q (adds five entries to the Q. Packs the Q if needed
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return rc;
+		}
+
+		while (QStart != traceQIn) {
+			if ((caTraceQ[QStart].record & TraceDqrProfiler::CAVFLAG_V0) != 0) {
+				pipe = TraceDqrProfiler::CAFLAG_PIPE0;
+				cycles = caTraceQ[QStart].cycle;
+				caTraceQ[QStart].record &= ~TraceDqrProfiler::CAVFLAG_V0;
+
+				//				QStart += 1;
+				//				if (QStart >= traceQSize) {
+				//					QStart = 0;
+				//				}
+
+				return TraceDqrProfiler::DQERR_OK;
+			}
+
+			if ((caTraceQ[QStart].record & TraceDqrProfiler::CAVFLAG_V1) != 0) {
+				pipe = TraceDqrProfiler::CAFLAG_PIPE1;
+				cycles = caTraceQ[QStart].cycle;
+				caTraceQ[QStart].record &= ~TraceDqrProfiler::CAVFLAG_V1;
+
+				//				QStart += 1;
+				//				if (QStart >= traceQSize) {
+				//					QStart = 0;
+				//				}
+
+				return TraceDqrProfiler::DQERR_OK;
+			}
+
+			QStart += 1;
+			if (QStart >= traceQSize) {
+				QStart = 0;
+			}
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::consumeCAVector(int& QStart, TraceDqrProfiler::CAVectorTraceFlags type, uint32_t& cycles, uint8_t& qInfo, uint8_t& arithInfo, uint8_t& loadInfo, uint8_t& storeInfo)
+{
+	if (caTraceQ == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// first look for pipe info in Q
+
+	// look in Q and see if record with matching type is found
+
+	TraceDqrProfiler::DQErr rc;
+
+	// QStart will be either traceQOut or after traceQOut
+
+	if (QStart == traceQIn) {
+		// get next record
+
+		rc = parseNextVectorRecord(QStart);	// reads a record and adds it to the Q (adds five entries to the Q. Packs the Q if needed
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return rc;
+		}
+	}
+
+	// we want the stats below at the beginning of the Q, not the end, so we grab them here!
+
+	uint8_t tQInfo = caTraceQ[QStart].qDepth;
+	uint8_t tArithInfo = caTraceQ[QStart].arithInProcess;
+	uint8_t tLoadInfo = caTraceQ[QStart].loadInProcess;
+	uint8_t tStoreInfo = caTraceQ[QStart].storeInProcess;
+
+	while (QStart != traceQIn) {
+		switch (type) { // type is what we are looking for. When we find a VISTART in the Q, it means one was removed from the Q!
+		case TraceDqrProfiler::CAVFLAG_VISTART:
+			caTraceQ[QStart].qDepth += 1;
+			break;
+		case TraceDqrProfiler::CAVFLAG_VIARITH:
+			caTraceQ[QStart].arithInProcess += 1;
+			break;
+		case TraceDqrProfiler::CAVFLAG_VISTORE:
+			caTraceQ[QStart].storeInProcess += 1;
+			break;
+		case TraceDqrProfiler::CAVFLAG_VILOAD:
+			caTraceQ[QStart].loadInProcess += 1;
+			break;
+		default:
+			printf("Error: ProfilerCATrace::consumeCAVector(): invalid type: %08x\n", type);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if ((caTraceQ[QStart].record & type) != 0) { // found what we were looking for in the q
+			cycles = caTraceQ[QStart].cycle;
+			caTraceQ[QStart].record &= ~type;
+
+			switch (type) {
+			case TraceDqrProfiler::CAVFLAG_VISTART:
+				tQInfo += 1;
+				break;
+			case TraceDqrProfiler::CAVFLAG_VIARITH:
+				tArithInfo += 1;
+				break;
+			case TraceDqrProfiler::CAVFLAG_VISTORE:
+				tStoreInfo += 1;
+				break;
+			case TraceDqrProfiler::CAVFLAG_VILOAD:
+				tLoadInfo += 1;
+				break;
+			default:
+				printf("Error: ProfilerCATrace::consumeCAVector(): invalid type: %08x\n", type);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			qInfo = tQInfo;
+			arithInfo = tArithInfo;
+			loadInfo = tLoadInfo;
+			storeInfo = tStoreInfo;
+
+			QStart += 1;
+			if (QStart >= traceQSize) {
+				QStart = 0;
+			}
+
+			return TraceDqrProfiler::DQERR_OK;
+		}
+
+		QStart += 1;
+
+		if (QStart >= traceQSize) {
+			QStart = 0;
+		}
+	}
+
+
+	// otherwise, start reading records and adding them to the Q until
+	// matching type is found
+
+	for (;;) {
+		// get next record
+
+		rc = parseNextVectorRecord(QStart);	// reads a record and adds it to the Q (adds five entries to the Q. Packs the Q if needed
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return rc;
+		}
+
+		while (QStart != traceQIn) {
+			switch (type) {
+			case TraceDqrProfiler::CAVFLAG_VISTART:
+				caTraceQ[QStart].qDepth += 1;
+				break;
+			case TraceDqrProfiler::CAVFLAG_VIARITH:
+				caTraceQ[QStart].arithInProcess += 1;
+				break;
+			case TraceDqrProfiler::CAVFLAG_VISTORE:
+				caTraceQ[QStart].storeInProcess += 1;
+				break;
+			case TraceDqrProfiler::CAVFLAG_VILOAD:
+				caTraceQ[QStart].loadInProcess += 1;
+				break;
+			default:
+				printf("Error: ProfilerCATrace::consumeCAVector(): invalid type: %08x\n", type);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if ((caTraceQ[QStart].record & type) != 0) {
+				cycles = caTraceQ[QStart].cycle;
+				caTraceQ[QStart].record &= ~type;
+
+				switch (type) {
+				case TraceDqrProfiler::CAVFLAG_VISTART:
+					tQInfo += 1;
+					break;
+				case TraceDqrProfiler::CAVFLAG_VIARITH:
+					tArithInfo += 1;
+					break;
+				case TraceDqrProfiler::CAVFLAG_VISTORE:
+					tStoreInfo += 1;
+					break;
+				case TraceDqrProfiler::CAVFLAG_VILOAD:
+					tLoadInfo += 1;
+					break;
+				default:
+					printf("Error: ProfilerCATrace::consumeCAVector(): invalid type: %08x\n", type);
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				qInfo = tQInfo;
+				arithInfo = tArithInfo;
+				loadInfo = tLoadInfo;
+				storeInfo = tStoreInfo;
+
+				QStart += 1;
+				if (QStart >= traceQSize) {
+					QStart = 0;
+				}
+
+				return TraceDqrProfiler::DQERR_OK;
+			}
+
+			QStart += 1;
+
+			if (QStart >= traceQSize) {
+				QStart = 0;
+			}
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+void ProfilerCATrace::dumpCAQ()
+{
+	printf("dumpCAQ(): traceQSize: %d traceQOut: %d traceQIn: %d\n", traceQSize, traceQOut, traceQIn);
+
+	for (int i = traceQOut; i != traceQIn;) {
+		printf("Q[%d]: %4d %02x", i, caTraceQ[i].cycle, caTraceQ[i].record);
+
+		if (caTraceQ[i].record & TraceDqrProfiler::CAVFLAG_V0) {
+			printf(" V0");
+		}
+		else {
+			printf("   ");
+		}
+
+		if (caTraceQ[i].record & TraceDqrProfiler::CAVFLAG_V1) {
+			printf(" V1");
+		}
+		else {
+			printf("   ");
+		}
+
+		if (caTraceQ[i].record & TraceDqrProfiler::CAVFLAG_VISTART) {
+			printf(" VISTART");
+		}
+		else {
+			printf("        ");
+		}
+
+		if (caTraceQ[i].record & TraceDqrProfiler::CAVFLAG_VIARITH) {
+			printf(" VIARITH");
+		}
+		else {
+			printf("         ");
+		}
+
+		if (caTraceQ[i].record & TraceDqrProfiler::CAVFLAG_VISTORE) {
+			printf(" VSTORE");
+		}
+		else {
+			printf("       ");
+		}
+
+		if (caTraceQ[i].record & TraceDqrProfiler::CAVFLAG_VILOAD) {
+			printf(" VLOAD\n");
+		}
+		else {
+			printf("       \n");
+		}
+
+		i += 1;
+		if (i >= traceQSize) {
+			i = 0;
+		}
+	}
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::consume(uint32_t& caFlags, TraceDqrProfiler::InstType iType, uint32_t& pipeCycles, uint32_t& viStartCycles, uint32_t& viFinishCycles, uint8_t& qDepth, uint8_t& arithDepth, uint8_t& loadDepth, uint8_t& storeDepth)
+{
+	int qStart;
+
+	TraceDqrProfiler::DQErr rc;
+
+	//	printf("ProfilerCATrace::consume()\n");
+
+	if (status != TraceDqrProfiler::DQERR_OK) {
+		return status;
+	}
+
+	uint8_t tQDepth;
+	uint8_t tArithDepth;
+	uint8_t tLoadDepth;
+	uint8_t tStoreDepth;
+
+	switch (caType) {
+	case TraceDqrProfiler::CATRACE_NONE:
+		printf("Error: ProfilerCATrace::consume(): invalid trace type CATRACE_NONE\n");
+		return TraceDqrProfiler::DQERR_ERR;
+	case TraceDqrProfiler::CATRACE_INSTRUCTION:
+		rc = consumeCAInstruction(caFlags, pipeCycles);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return rc;
+		}
+
+		qDepth = 0;
+		arithDepth = 0;
+		loadDepth = 0;
+		storeDepth = 0;
+		break;
+	case TraceDqrProfiler::CATRACE_VECTOR:
+		// get pipe
+
+		qStart = traceQOut;
+
+		rc = consumeCAPipe(qStart, pipeCycles, caFlags);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return status;
+		}
+
+		switch (iType) {
+		case TraceDqrProfiler::INST_VECT_ARITH:
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VISTART, viStartCycles, qDepth, tArithDepth, tLoadDepth, tStoreDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VIARITH, viFinishCycles, tQDepth, arithDepth, loadDepth, storeDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			caFlags |= TraceDqrProfiler::CAFLAG_VSTART | TraceDqrProfiler::CAFLAG_VARITH;
+
+			if (profiler_globalDebugFlag) {
+				printf("ProfilerCATrace::consume(): INST_VECT_ARITH consumed vector instruction. Current qStart: %d traceQOut: %d traceQIn: %d\n", qStart, traceQOut, traceQIn);
+				printf("vector: viFinishCycles: %d\n", viFinishCycles);
+				dumpCAQ();
+			}
+			break;
+		case TraceDqrProfiler::INST_VECT_LOAD:
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VISTART, viStartCycles, qDepth, tArithDepth, tLoadDepth, tStoreDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VILOAD, viFinishCycles, tQDepth, arithDepth, loadDepth, storeDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			caFlags |= TraceDqrProfiler::CAFLAG_VSTART | TraceDqrProfiler::CAFLAG_VLOAD;
+
+			if (profiler_globalDebugFlag) {
+				printf("ProfilerCATrace::consume(): INST_VECT_LOAD consumed vector instruction. Current qStart: %d traceQOut: %d traceQIn: %d\n", qStart, traceQOut, traceQIn);
+				printf("vector: viFinishCycles: %d\n", viFinishCycles);
+				dumpCAQ();
+			}
+			break;
+		case TraceDqrProfiler::INST_VECT_STORE:
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VISTART, viStartCycles, qDepth, tArithDepth, tLoadDepth, tStoreDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VISTORE, viFinishCycles, tQDepth, arithDepth, loadDepth, storeDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			caFlags |= TraceDqrProfiler::CAFLAG_VSTART | TraceDqrProfiler::CAFLAG_VSTORE;
+
+			if (profiler_globalDebugFlag) {
+				printf("ProfilerCATrace::consume(): INST_VECT_STORE consumed vector instruction. Current qStart: %d traceQOut: %d traceQIn: %d\n", qStart, traceQOut, traceQIn);
+				printf("vector: viFinishCycles: %d\n", viFinishCycles);
+				dumpCAQ();
+			}
+			break;
+		case TraceDqrProfiler::INST_VECT_AMO:
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VISTART, viStartCycles, qDepth, tArithDepth, tLoadDepth, tStoreDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VILOAD, viFinishCycles, tQDepth, arithDepth, loadDepth, storeDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			caFlags |= TraceDqrProfiler::CAFLAG_VSTART | TraceDqrProfiler::CAFLAG_VLOAD;
+
+			if (profiler_globalDebugFlag) {
+				printf("ProfilerCATrace::consume(): INST_VECT_AMO consumed vector instruction. Current qStart: %d traceQOut: %d traceQIn: %d\n", qStart, traceQOut, traceQIn);
+				printf("vector: viFinishCycles: %d\n", viFinishCycles);
+				dumpCAQ();
+			}
+			break;
+		case TraceDqrProfiler::INST_VECT_AMO_WW:
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VISTART, viStartCycles, qDepth, tArithDepth, tLoadDepth, tStoreDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VILOAD, viFinishCycles, tQDepth, arithDepth, loadDepth, storeDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			rc = consumeCAVector(qStart, TraceDqrProfiler::CAVFLAG_VISTORE, viFinishCycles, tQDepth, tArithDepth, tLoadDepth, tStoreDepth);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+				return rc;
+			}
+
+			caFlags |= TraceDqrProfiler::CAFLAG_VSTART | TraceDqrProfiler::CAFLAG_VLOAD | TraceDqrProfiler::CAFLAG_VSTORE;
+
+			if (profiler_globalDebugFlag) {
+				printf("ProfilerCATrace::consume(): INST_VECT_AMO consumed vector instruction. Current qStart: %d traceQOut: %d traceQIn: %d\n", qStart, traceQOut, traceQIn);
+				printf("vector: viFinishCycles: %d\n", viFinishCycles);
+				dumpCAQ();
+			}
+			break;
+		case TraceDqrProfiler::INST_VECT_CONFIG:
+			break;
+		default:
+			break;
+		}
+
+		// update traceQOut for vector traces
+
+		while ((caTraceQ[traceQOut].record == 0) && (traceQOut != traceQIn)) {
+			traceQOut += 1;
+			if (traceQOut >= traceQSize) {
+				traceQOut = 0;
+			}
+		}
+		break;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::ADDRESS ProfilerCATrace::getCATraceStartAddr()
+{
+	// of course it ins't this simple. If bit 29 in data[0] is 0, the start address is actually the address of the next
+	// instruction! To compute that, we must know the size of the instruction at the reported address. And to make things
+	// worse, if that instruction is a conditional branch or an indirect jump (like a return), we can't compute the next
+	// address because there is not instruction trace info for that instruction!
+
+	return startAddr;
+}
+
+TraceDqrProfiler::DQErr ProfilerCATrace::parseNextCATraceRec(ProfilerCATraceRec& car)
+{
+	// Reload all 32 catr.data[] records from the raw caBuffer[] data. Update caBufferIndex to start of next record in raw data
+	// Works for CAInstruction and CAVector traces
+
+	// needs to update offset and blockRecordNum as well!
+
+	if (status != TraceDqrProfiler::DQERR_OK) {
+		return status;
+	}
+
+	if ((int)caBufferIndex > (int)(caBufferSize - sizeof(uint32_t))) {
+		status = TraceDqrProfiler::DQERR_EOF;
+		return TraceDqrProfiler::DQERR_EOF;
+	}
+
+	uint32_t d = 0;
+	bool firstRecord;
+
+	if (caBufferIndex == 0) {
+		// find start of first message (in case buffer wrapped)
+		uint32_t last;
+
+		firstRecord = true;
+
+		do {
+			last = d >> 30;
+			d = *(uint32_t*)(&caBuffer[caBufferIndex]);
+			caBufferIndex += sizeof(uint32_t);
+
+			if ((int)caBufferIndex > (int)(caBufferSize - sizeof(uint32_t))) {
+				status = TraceDqrProfiler::DQERR_EOF;
+				return TraceDqrProfiler::DQERR_EOF;
+			}
+		} while (((d >> 30) != 0x3) && (last != 0));
+	}
+	else {
+		firstRecord = false;
+
+		// need to get first word into d
+		d = *(uint32_t*)(&caBuffer[caBufferIndex]);
+		caBufferIndex += sizeof(uint32_t);
+	}
+
+	// make sure there are at least 31 more 32 bit records in the caBuffer. If not, EOF
+
+	if ((int)caBufferIndex > (int)(caBufferSize - sizeof(uint32_t) * 31)) {
+		return TraceDqrProfiler::DQERR_EOF;
+	}
+
+	TraceDqrProfiler::ADDRESS addr;
+	addr = 0;
+
+	car.data[0] = d & 0x3fffffff;
+
+	for (int i = 1; i < 32; i++) {
+		d = *(uint32_t*)(&caBuffer[caBufferIndex]);
+		caBufferIndex += sizeof(uint32_t);
+
+		// don't need to check caBufferIndex for EOF because of the check before for loop
+
+		addr |= (((TraceDqrProfiler::ADDRESS)(d >> 30)) << 2 * (i - 1));
+		car.data[i] = d & 0x3fffffff;
+	}
+
+	if (firstRecord != false) {
+		car.data[0] |= (1 << 29); // set the pipe0 finish flag for first bit of trace file (vector or instruction)
+		blockRecNum = 0;
+	}
+	else {
+		blockRecNum += 1;
+	}
+
+	car.address = addr;
+	car.offset = 0;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+#if 1
+// might need to add binary struct at beginning of metadata file??
+
+static const char* const CTFMetadataHeader =
+"/* PROFILER_CTF 1.8 */\n"
+"\n";
+
+static const char* const CTFMetadataTypeAlias =
+"typealias integer {size = 8; align = 8; signed = false; } := uint8_t;\n"
+"typealias integer {size = 16; align = 8; signed = false; } := uint16_t;\n"
+"typealias integer {size = 32; align = 8; signed = false; } := uint32_t;\n"
+"typealias integer {size = 64; align = 8; signed = false; } := uint64_t;\n"
+"typealias integer {size = 64; align = 8; signed = false; } := unsigned long;\n"
+"typealias integer {size = 5; align = 8; signed = false; } := uint5_t;\n"
+"typealias integer {size = 27; align = 8; signed = false; } := uint27_t;\n"
+"\n";
+
+static const char* const CTFMetadataTraceDef =
+"trace {\n"
+"\tmajor = 1;\n"
+"\tminor = 8;\n"
+"\tbyte_order = le;\n"
+"\tpacket.header := struct {\n"
+"\t\tuint32_t magic;\n"
+"\t\tuint32_t stream_id;\n"
+"\t};\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataEnvDef =
+"env {\n"
+"\tdomain = \"ust\";\n"
+"\ttracer_name = \"lttng-ust\";\n"
+"\ttracer_major = 2;\n"
+"\ttracer_minor = 11;\n"
+"\ttracer_buffering_scheme = \"uid\";\n"
+"\ttracer_buffering_id = 1000;\n"
+"\tarchitecture_bit_width = %d;\n"
+"\ttrace_name = \"%s\";\n"
+"\ttrace_creation_datetime = \"%s\";\n"
+"\thostname = \"%s\";\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataClockDef =
+"clock {\n"
+"\tname = \"monotonic\";\n"
+"\tuuid = \"cb35f5a5-f0a6-441f-b5c7-c7fb50c2e051\";\n"
+"\tdescription = \"Monotonic Clock\";\n"
+"\tfreq = %d; /* Frequency, in Hz */\n"
+"\t/* clock value offset from Epoch is: offset * (1/freq) */\n"
+"\toffset = %lld;\n"
+"};\n"
+"\n"
+"typealias integer {\n"
+"\tsize = 27; align = 1; signed = false;\n"
+"\tmap = clock.monotonic.value;\n"
+"} := uint27_clock_monotonic_t;\n"
+"\n"
+"typealias integer {\n"
+"\tsize = 32; align = 8; signed = false;\n"
+"\tmap = clock.monotonic.value;\n"
+"} := uint32_clock_monotonic_t;\n"
+"\n"
+"typealias integer {\n"
+"\tsize = 64; align = 8; signed = false;\n"
+"\tmap = clock.monotonic.value;\n"
+"} := uint64_clock_monotonic_t;\n"
+"\n";
+
+static const char* const CTFMetadataPacketContext =
+"struct packet_context {\n"
+"\tuint64_clock_monotonic_t timestamp_begin;\n"
+"\tuint64_clock_monotonic_t timestamp_end;\n"
+"\tuint64_t content_size;\n"
+"\tuint64_t packet_size;\n"
+"\tuint64_t packet_seq_num;\n"
+"\tunsigned long events_discarded;\n"
+"\tuint32_t cpu_id;\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataEventHeaders =
+"struct event_header_compact {\n"
+"\tenum : uint5_t { compact = 0 ... 30, extended = 31 } id;\n"
+"\tvariant <id> {\n"
+"\t\tstruct {\n"
+"\t\t\tuint27_clock_monotonic_t timestamp;\n"
+"\t\t} compact;\n"
+"\t\tstruct {\n"
+"\t\t\tuint32_t id;\n"
+"\t\t\tuint64_clock_monotonic_t timestamp;\n"
+"\t\t} extended;\n"
+"\t} v;\n"
+"} align(8);\n"
+"\n"
+"struct event_header_large {\n"
+"\tenum : uint16_t { compact = 0 ... 65534, extended = 65535 } id;\n"
+"\tvariant <id> {\n"
+"\t\tstruct {\n"
+"\t\t\tuint32_clock_monotonic_t timestamp;\n"
+"\t\t} compact;\n"
+"\t\tstruct {\n"
+"\t\t\tuint32_t id;\n"
+"\t\t\tuint64_clock_monotonic_t timestamp;\n"
+"\t\t} extended;\n"
+"\t} v;\n"
+"} align(8);\n"
+"\n";
+
+static const char* const CTFMetadataStreamDef =
+"stream {\n"
+"\tid = 0;\n"
+"\tevent.header := struct event_header_large;\n"
+"\tpacket.context := struct packet_context;\n"
+"\tevent.context := struct {\n"
+"\t\tinteger { size = 32; align = 8; signed = 1; encoding = none; base = 10; } _vpid;\n"
+"\t\tinteger { size = 32; align = 8; signed = 1; encoding = none; base = 10; } _vtid;\n"
+"\t\tinteger { size = 8; align = 8; signed = 1; encoding = UTF8; base = 10; } _procname[17];\n"
+"\t};\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataCallEventDef =
+"event {\n"
+"\tname = \"lttng_ust_cyg_profile:func_entry\";\n"
+"\tid = 1;\n"
+"\tstream_id = 0;\n"
+"\tloglevel = 12;\n"
+"\tfields := struct {\n"
+"\t\tinteger { size = 64; align = 8; signed = 0; encoding = none; base = 16; } _addr;\n"
+"\t\tinteger { size = 64; align = 8; signed = 0; encoding = none; base = 16; } _call_site;\n"
+"\t};\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataRetEventDef =
+"event {\n"
+"\tname = \"lttng_ust_cyg_profile:func_exit\";\n"
+"\tid = 2;\n"
+"\tstream_id = 0;\n"
+"\tloglevel = 12;\n"
+"\tfields := struct {\n"
+"\t\tinteger { size = 64; align = 8; signed = 0; encoding = none; base = 16; } _addr;\n"
+"\t\tinteger { size = 64; align = 8; signed = 0; encoding = none; base = 16; } _call_site;\n"
+"\t};\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataStatedumpStart =
+"event {\n"
+"\tname = \"lttng_ust_statedump:start\";\n"
+"\tid = 3;\n"
+"\tstream_id = 0;\n"
+"\tloglevel = 13;\n"
+"\tfields := struct {\n"
+"\t};\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataStatedumpBinInfo =
+"event {\n"
+"\tname = \"lttng_ust_statedump:bin_info\";\n"
+"\tid = 4;\n"
+"\tstream_id = 0;\n"
+"\tloglevel = 13;\n"
+"\tfields := struct {\n"
+"\t\tinteger { size = 64; align = 8; signed = 0; encoding = none; base = 16; } _baddr;\n"
+"\t\tinteger { size = 64; align = 8; signed = 0; encoding = none; base = 10; } _memsz;\n"
+"\t\tstring _path;\n"
+"\t\tinteger { size = 8; align = 8; signed = 0; encoding = none; base = 10; } _is_pic;\n"
+"\t\tinteger { size = 8; align = 8; signed = 0; encoding = none; base = 10; } _has_build_id;\n"
+"\t\tinteger { size = 8; align = 8; signed = 0; encoding = none; base = 10; } _has_debug_link;\n"
+"\t};\n"
+"};\n"
+"\n";
+
+static const char* const CTFMetadataStatedumpEnd =
+"event {\n"
+"\tname = \"lttng_ust_statedump:end\";\n"
+"\tid = 7;\n"
+"\tstream_id = 0;\n"
+"\tloglevel = 13;\n"
+"\tfields := struct {\n"
+"\t};\n"
+"};\n"
+"\n";
+
+static char CTFMetadataEnvDefDoctored[1024];
+static char CTFMetadataClockDefDoctored[1024];
+
+static const char* const CTFMetadataStructs[] = {
+		CTFMetadataHeader,
+		CTFMetadataTypeAlias,
+		CTFMetadataTraceDef,
+		CTFMetadataEnvDefDoctored,
+		CTFMetadataClockDefDoctored, // need to put freq in string!
+		CTFMetadataPacketContext,
+		CTFMetadataEventHeaders,
+		CTFMetadataStreamDef,
+		CTFMetadataCallEventDef,
+		CTFMetadataRetEventDef,
+		CTFMetadataStatedumpStart,
+		CTFMetadataStatedumpBinInfo,
+		CTFMetadataStatedumpEnd
+};
+
+// class TraceSettings methods
+
+TraceSettings::TraceSettings()
+{
+	odName = nullptr;
+	tfName = nullptr;
+	efName = nullptr;
+	caName = nullptr;
+	pfName = nullptr;
+	caType = TraceDqrProfiler::CATRACE_NONE;
+	srcBits = 0;
+	numAddrBits = 0;
+	itcPrintOpts = TraceDqrProfiler::ITC_OPT_NLS;
+	itcPrintBufferSize = 4096;
+	itcPrintChannel = 0;
+	itcPerfEnable = false;
+	itcPerfChannel = 6;
+	itcPerfMarkerValue = (uint32_t)(('p' << 24) | ('e' << 16) | ('r' << 8) | ('f' << 0));
+	cutPath = nullptr;
+	srcRoot = nullptr;
+	pathType = TraceDqrProfiler::PATH_TO_UNIX;
+	freq = 0;
+	addrDispFlags = 0;
+	tsSize = 40;
+	CTFConversion = false;
+	eventConversionEnable = false;
+	startTime = -1;
+	hostName = nullptr;
+	filterControlEvents = false;
+}
+
+TraceSettings::~TraceSettings()
+{
+	if (tfName != nullptr) {
+		delete[] tfName;
+		tfName = nullptr;
+	}
+
+	if (efName != nullptr) {
+		delete[] efName;
+		efName = nullptr;
+	}
+
+	if (caName != nullptr) {
+		delete[] caName;
+		caName = nullptr;
+	}
+
+	if (srcRoot != nullptr) {
+		delete[] srcRoot;
+		srcRoot = nullptr;
+	}
+
+	if (cutPath != nullptr) {
+		delete[] cutPath;
+		cutPath = nullptr;
+	}
+
+	if (hostName != nullptr) {
+		delete[] hostName;
+		hostName = nullptr;
+	}
+
+	if (odName != nullptr) {
+		delete[] odName;
+		odName = nullptr;
+	}
+}
+
+TraceDqrProfiler::DQErr TraceSettings::addSettings(propertiesParser* properties)
+{
+	TraceDqrProfiler::DQErr rc;
+	char* name = nullptr;
+	char* value = nullptr;
+
+	properties->rewind();
+
+	do {
+		rc = properties->getNextProperty(&name, &value);
+		if (rc == TraceDqrProfiler::DQERR_OK) {
+			//			printf("name: %s, value: %s\n",name,value);
+
+			if (strcasecmp("rtd",name) == 0) {
+				rc = propertyToTFName(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set trace file name in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("elf",name) == 0) {
+				rc = propertyToEFName(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set elf file name in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("pcd",name) == 0) {
+				rc = propertyToPFName(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could net set pcd file name in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("srcbits",name) == 0) {
+				rc = propertyToSrcBits(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set srcBits in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("bits",name) == 0) {
+				rc = propertyToNumAddrBits(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set numAddrBits in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("trace.config.boolean.enable.itc.print.processing",name) == 0) {
+				rc = propertyToITCPrintOpts(value); // value should be nul, true, or false
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set ITC print options in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("trace.config.int.itc.print.channel",name) == 0) {
+				rc = propertyToITCPrintChannel(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set ITC print channel value in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("trace.config.int.itc.print.buffersize",name) == 0) {
+				rc = propertyToITCPrintBufferSize(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set ITC print buffer size in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("trace.config.int.itc.perf",name) == 0) {
+				rc = propertyToITCPerfEnable(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set ITC perf enable flag in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("trace.config.int.itc.perf.channel",name) == 0) {
+				rc = propertyToITCPerfChannel(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set ITC perf channel in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("trace.config.int.itc.perf.marker",name) == 0) {
+				rc = propertyToITCPerfMarkerValue(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set ITC perf marker value in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("source.root",name) == 0) {
+				rc = propertyToSrcRoot(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set src root path in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("source.cutpath",name) == 0) {
+				rc = propertyToSrcCutPath(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set src cut path in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("caFile",name) == 0) {
+				rc = propertyToCAName(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set CA file name in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("caType",name) == 0) {
+				rc = propertyToCAType(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set CA type in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("TSSize",name) == 0) {
+				rc = propertyToTSSize(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set TS size in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("pathType",name) == 0) {
+				rc = propertyToPathType(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set path type in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("freq",name) == 0) {
+				rc = propertyToFreq(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set frequency in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("ctfenable",name) == 0) {
+				rc = propertyToCTFEnable(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set ctfEnable in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("eventConversionEnable",name) == 0) {
+				rc = propertyToEventConversionEnable(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set eventConversionEnable in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("addressdisplayflags", name) == 0) {
+				rc = propertyToAddrDispFlags(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set address display flags in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("starttime", name) == 0) {
+				rc = propertyToStartTime(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set start time in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("hostname", name) == 0) {
+				rc = propertyToHostName(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set host name in settings\n");
+					return rc;
+				}
+			}
+			else if (strcasecmp("objdump",name) == 0) {
+				rc = propertyToObjdumpName(value);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: TraceSettings::addSettings(): Could not set name of objdump executable in settings\n");
+					return rc;
+				}
+			}
+		}
+	} while (rc == TraceDqrProfiler::DQERR_OK);
+
+	// make sure perf and print channel are not the same!!
+
+	if (itcPerfEnable && (itcPrintOpts & TraceDqrProfiler::ITC_OPT_PRINT)) {
+		if (itcPrintChannel == itcPerfChannel) {
+			printf("Error: TraceSettings::addSettings(): itcPrintChannel and itcPerfChannel cannot be the same\n");
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	if (rc != TraceDqrProfiler::DQERR_EOF) {
+		printf("Error: TraceSettings::addSettings(): problem parsing properties file: %d\n", rc);
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToObjdumpName(const char* value)
+{
+	if (value != nullptr) {
+		if (odName != nullptr) {
+			delete[] odName;
+			odName = nullptr;
+		}
+
+		int l;
+		l = strlen(value) + 1;
+
+		odName = new char[l];
+		strcpy(odName, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToTFName(const char* value)
+{
+	if (value != nullptr) {
+		if (tfName != nullptr) {
+			delete[] tfName;
+			tfName = nullptr;
+		}
+
+		int l;
+		l = strlen(value) + 1;
+
+		tfName = new char[l];
+		strcpy(tfName, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToEFName(const char* value)
+{
+	if (value != nullptr) {
+		if (efName != nullptr) {
+			delete[] efName;
+			efName = nullptr;
+		}
+
+		int l;
+		l = strlen(value) + 1;
+
+		efName = new char[l];
+		strcpy(efName, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToPFName(const char* value)
+{
+	if (value != nullptr) {
+		if (pfName != nullptr) {
+			delete[] pfName;
+			pfName = nullptr;
+		}
+
+		int l;
+		l = strlen(value) + 1;
+
+		pfName = new char[l];
+		strcpy(pfName, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToAddrDispFlags(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		addrDispFlags = 0;
+
+		int l;
+		char* endptr;
+
+		l = strtol(value, &endptr, 10);
+
+		if (endptr[0] == 0) {
+			numAddrBits = l;
+			addrDispFlags = addrDispFlags & ~TraceDqrProfiler::ADDRDISP_WIDTHAUTO;
+		}
+		else if (endptr[0] == '+') {
+			numAddrBits = l;
+			addrDispFlags = addrDispFlags | TraceDqrProfiler::ADDRDISP_WIDTHAUTO;
+		}
+		else {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if ((l < 32) || (l > 64)) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToSrcBits(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		srcBits = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToNumAddrBits(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		numAddrBits = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToITCPrintOpts(const char* value)
+{
+	TraceDqrProfiler::DQErr rc;
+	bool opts;
+
+	rc = propertyToBool(value, opts);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return rc;
+	}
+
+	if (opts) {
+		itcPrintOpts = TraceDqrProfiler::ITC_OPT_PRINT | TraceDqrProfiler::ITC_OPT_NLS;
+	}
+	else {
+		itcPrintOpts = TraceDqrProfiler::ITC_OPT_NLS;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToITCPrintChannel(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		itcPrintChannel = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToITCPrintBufferSize(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		itcPrintBufferSize = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToITCPerfEnable(const char* value)
+{
+	TraceDqrProfiler::DQErr rc;
+	bool opts;
+
+	rc = propertyToBool(value, opts);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return rc;
+	}
+
+	if (opts) {
+		itcPerfEnable = true;
+	}
+	else {
+		itcPerfEnable = false;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToITCPerfChannel(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		itcPerfChannel = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToITCPerfMarkerValue(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		itcPerfMarkerValue = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToSrcRoot(const char* value)
+{
+	if (value != nullptr) {
+		if (srcRoot != nullptr) {
+			delete[] srcRoot;
+			srcRoot = nullptr;
+		}
+
+		int l;
+		l = strlen(value) + 1;
+
+		srcRoot = new char[l];
+		strcpy(srcRoot, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToSrcCutPath(const char* value)
+{
+	if (value != nullptr) {
+		if (cutPath != nullptr) {
+			delete[] cutPath;
+			cutPath = nullptr;
+		}
+
+		int l;
+		l = strlen(value) + 1;
+
+		cutPath = new char[l];
+		strcpy(cutPath, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToCAName(const char* value)
+{
+	if (value != nullptr) {
+		int l;
+		l = strlen(value) + 1;
+
+		caName = new char[l];
+		strcpy(caName, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToCAType(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		if (strcasecmp(value,"none") == 0) {
+			caType = TraceDqrProfiler::CATRACE_NONE;
+		}
+		else if (strcasecmp(value,"catrace_none") == 0) {
+			caType = TraceDqrProfiler::CATRACE_NONE;
+		}
+		else if (strcasecmp(value,"vector") == 0) {
+			caType = TraceDqrProfiler::CATRACE_VECTOR;
+		}
+		else if (strcasecmp(value,"catrace_vector") == 0) {
+			caType = TraceDqrProfiler::CATRACE_VECTOR;
+		}
+		else if (strcasecmp(value,"instruction") == 0) {
+			caType = TraceDqrProfiler::CATRACE_INSTRUCTION;
+		}
+		else if (strcasecmp(value,"catrace_instruction") == 0) {
+			caType = TraceDqrProfiler::CATRACE_INSTRUCTION;
+		}
+		else {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToPathType(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		if (strcasecmp("unix",value) == 0) {
+			pathType = TraceDqrProfiler::PATH_TO_UNIX;
+		}
+		else if (strcasecmp("windows",value) == 0) {
+			pathType = TraceDqrProfiler::PATH_TO_WINDOWS;
+		}
+		else if (strcasecmp("raw",value) == 0) {
+			pathType = TraceDqrProfiler::PATH_RAW;
+		}
+		else {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToBool(const char* src, bool& value)
+{
+	if ((src != nullptr) && (src[0] != '\0')) {
+		if (strcasecmp("true",src) == 0) {
+			value = true;		}
+		else if (strcasecmp("false",src) == 0) {
+			value = false;
+		}
+		else {
+			char* endp;
+
+			value = strtol(src, &endp, 0);
+			if (endp == src) {
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+		}
+	}
+	else {
+		value = false;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToCTFEnable(const char* value)
+{
+	return propertyToBool(value, CTFConversion);
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToEventConversionEnable(const char* value)
+{
+	return propertyToBool(value, eventConversionEnable);
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToFreq(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		freq = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToStartTime(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		startTime = (int64_t)strtoll(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToHostName(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		if (hostName != nullptr) {
+			delete[] hostName;
+			hostName = nullptr;
+		}
+
+		int l;
+		l = strlen(value) + 1;
+
+		hostName = new char[l];
+		strcpy(hostName, value);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceSettings::propertyToTSSize(const char* value)
+{
+	if ((value != nullptr) && (value[0] != '\0')) {
+		char* endp;
+
+		tsSize = strtol(value, &endp, 0);
+
+		if (endp == value) {
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+// class propertiesParser methods
+
+propertiesParser::propertiesParser(const char* srcData)
+{
+	status = TraceDqrProfiler::DQERR_OK;
+
+	propertiesBuff = nullptr;
+	lines = nullptr;
+	numLines = 0;
+	nextLine = 0;
+	size = 0;
+
+	if (srcData == nullptr) {
+		return;
+	}
+
+	std::ifstream  f;
+
+	f.open(srcData, std::ifstream::binary);
+	if (!f) {
+		printf("Error: propertiesParser::propertiesParser(): could not open file %s for input\n", srcData);
+
+		status = TraceDqrProfiler::DQERR_OPEN;
+		return;
+	}
+
+	// get length of file:
+
+	f.seekg(0, f.end);
+	size = f.tellg();
+	f.seekg(0, f.beg);
+
+	if (size < 0) {
+		printf("Error: propertiesParser::propertiesParser(): could not get size of file %s for input\n", srcData);
+
+		f.close();
+
+		status = TraceDqrProfiler::DQERR_OPEN;
+		return;
+	}
+
+	// allocate memory:
+
+	propertiesBuff = new char[size + 1]; // allocate an extra byte in case the file doesn't end with \n
+
+	// read file into buffer
+
+	f.read(propertiesBuff, size);
+	int numRead = f.gcount();
+	f.close();
+
+	if (numRead != size) {
+		printf("Error: propertiesParser::propertiesParser(): could not read file %s into memory\n", srcData);
+
+		delete[] propertiesBuff;
+		propertiesBuff = nullptr;
+		size = 0;
+
+		status = TraceDqrProfiler::DQERR_OPEN;
+		return;
+	}
+
+	// count lines
+
+	numLines = 0;
+
+	for (int i = 0; i < size; i++) {
+		if (propertiesBuff[i] == '\n') {
+			numLines += 1;
+		}
+		else if (i == size - 1) {
+			// last line does not have a \n
+			numLines += 1;
+		}
+	}
+
+	// create array of line pointers
+
+	lines = new line[numLines];
+
+	// initialize array of ptrs
+
+	int l;
+	int s;
+
+	l = 0;
+	s = 1;
+
+	for (int i = 0; i < numLines; i++) {
+		lines[i].line = nullptr;
+		lines[i].name = nullptr;
+		lines[i].value = nullptr;
+	}
+
+	for (int i = 0; i < size; i++) {
+		if (s != 0) {
+			lines[l].line = &propertiesBuff[i];
+			l += 1;
+			s = 0;
+		}
+
+		// strip out CRs and LFs
+
+		if (propertiesBuff[i] == '\r') {
+			propertiesBuff[i] = 0;
+		}
+		else if (propertiesBuff[i] == '\n') {
+			propertiesBuff[i] = 0;
+			s = 1;
+		}
+	}
+
+	propertiesBuff[size] = 0;	// make sure last line is nul terminated
+
+	if (l != numLines) {
+		printf("Error: propertiesParser::propertiesParser(): Error computing line count for file %s, l:%d, lc: %d\n", srcData, l, numLines);
+
+		delete[] lines;
+		lines = nullptr;
+		delete[] propertiesBuff;
+		propertiesBuff = nullptr;
+		size = 0;
+		numLines = 0;
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+}
+
+propertiesParser::~propertiesParser()
+{
+	if (propertiesBuff != nullptr) {
+		delete[] propertiesBuff;
+		propertiesBuff = nullptr;
+	}
+
+	if (lines != nullptr) {
+		delete[] lines;
+		lines = nullptr;
+	}
+}
+
+void propertiesParser::rewind()
+{
+	nextLine = 0;
+}
+
+TraceDqrProfiler::DQErr propertiesParser::getNextToken(char* inputText, int& startIndex, int& endIndex)
+{
+	if (inputText == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// stripi ws
+
+	bool found;
+
+	for (found = false; !found; ) {
+		switch (inputText[startIndex]) {
+		case '\t':
+		case ' ':
+			// skip this char
+			startIndex += 1;
+			break;
+		default:
+			found = true;
+			break;
+		}
+	}
+
+	endIndex = startIndex;
+
+	// check for end of line
+
+	switch (inputText[startIndex]) {
+	case '#':
+	case '\0':
+	case '\n':
+	case '\r':
+		// end of line. If end == start, nothing was found
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	// scan to end of token
+
+	// will not start with #, =, \0, \r, \n
+	// so scan until we find an end
+
+	for (found = false; !found; ) {
+		switch (inputText[endIndex]) {
+		case ' ':
+		case '#':
+		case '\0':
+		case '\n':
+		case '\r':
+			found = true;
+			break;
+		case '=':
+			if (startIndex == endIndex) {
+				endIndex += 1;
+			}
+			found = true;
+			break;
+		default:
+			endIndex += 1;
+		}
+	}
+
+	//	printf("getNextToken(): start %d, end %d ,'",startIndex,endIndex);
+	//	for (int i = startIndex; i < endIndex; i++) {
+	//		printf("%c",inputText[i]);
+	//	}
+	//	printf("'\n");
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr propertiesParser::getNextProperty(char** name, char** value)
+{
+	if (status != TraceDqrProfiler::DQERR_OK) {
+		return status;
+	}
+
+	if (lines == nullptr) {
+		status = TraceDqrProfiler::DQERR_EOF;
+		return TraceDqrProfiler::DQERR_EOF;
+	}
+
+	if ((name == nullptr) || (value == nullptr)) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// if we are at the end, return EOF
+
+	if (nextLine >= numLines) {
+		return TraceDqrProfiler::DQERR_EOF;
+	}
+
+	// If this name/value pair has already been found, return it
+
+	if ((lines[nextLine].name != nullptr) && (lines[nextLine].value != nullptr)) {
+		*name = lines[nextLine].name;
+		*value = lines[nextLine].value;
+
+		nextLine += 1;
+
+		return TraceDqrProfiler::DQERR_OK;
+	}
+
+	// get name
+
+	int nameStart = 0;
+	int nameEnd = 0;
+
+	TraceDqrProfiler::DQErr rc;
+
+	do {
+		rc = getNextToken(lines[nextLine].line, nameStart, nameEnd);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return rc;
+		}
+
+		if (nameStart == nameEnd) {
+			nextLine += 1;
+		}
+	} while ((nameStart == nameEnd) && (nextLine < numLines));
+
+	if (nextLine >= numLines) {
+		return TraceDqrProfiler::DQERR_EOF;
+	}
+
+	// check if we got a name, or an '='
+
+	if (((nameStart - nameEnd) == 1) && (lines[nextLine].line[nameStart] == '=')) {
+		// error - name cannot be '='
+		printf("Error: propertiesParser::getNextProperty(): Line %d: syntax error\n", nextLine);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	int eqStart = nameEnd;
+	int eqEnd = nameEnd;
+
+	// get '='
+	rc = getNextToken(lines[nextLine].line, eqStart, eqEnd);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+		return rc;
+	}
+
+	if ((eqStart == eqEnd) || ((eqEnd - eqStart) != 1) || (lines[nextLine].line[eqStart] != '=')) {
+		printf("Error: propertiesParser::getNextProperty(): Line %d: expected '='\n", nextLine);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// get value or end of line
+
+	int valueStart = eqEnd;
+	int valueEnd = eqEnd;
+
+	rc = getNextToken(lines[nextLine].line, valueStart, valueEnd);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+		return rc;
+	}
+
+	if (((valueStart - valueEnd) == 1) && (lines[nextLine].line[nameStart] == '=')) {
+		// error - value cannot be '='
+		printf("Error: propertiesParser::getNextProperty(): Line %d: syntax error\n", nextLine);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	lines[nextLine].line[nameEnd] = 0;
+	lines[nextLine].name = &lines[nextLine].line[nameStart];
+
+	*name = lines[nextLine].name;
+
+	lines[nextLine].line[valueEnd] = 0;
+	lines[nextLine].value = &lines[nextLine].line[valueStart];
+
+	*value = lines[nextLine].value;
+
+	nextLine += 1;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+#endif
+// class trace methods
+
+TraceProfiler::TraceProfiler(char* mf_name)
+{
+	sfp = nullptr;
+	elfReader = nullptr;
+	disassembler = nullptr;
+	caTrace = nullptr;
+	counts = nullptr;//delete this line if compile error
+	efName = nullptr;
+	rtdName = nullptr;
+	cutPath = nullptr;
+	newRoot = nullptr;
+	itcPrint = nullptr;
+	nlsStrings = nullptr;
+	ctf = nullptr;
+	eventConverter = nullptr;
+	perfConverter = nullptr;
+	objdump = nullptr;
+
+	if (mf_name == nullptr) {
+		printf("Error: TraceProfiler(): mf_name argument null\n");
+
+		cleanUp();
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+
+	propertiesParser properties(mf_name);
+
+	rc = properties.getStatus();
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: TraceProfiler(): new propertiesParser(%s) from file failed with %d\n", mf_name, rc);
+
+		cleanUp();
+
+		status = rc;
+		return;
+	}
+
+	TraceSettings settings;
+
+	rc = settings.addSettings(&properties);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: TraceProfiler(): addSettings() failed\n");
+
+		cleanUp();
+
+		status = rc;
+
+		return;
+	}
+
+	rc = configure(settings);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+
+		cleanUp();
+
+		return;
+	}
+
+	status = TraceDqrProfiler::DQERR_OK;
+}
+
+TraceProfiler::TraceProfiler(char* tf_name, char* ef_name, int numAddrBits, uint32_t addrDispFlags, int srcBits, const char* odExe, uint32_t freq)
+{
+	TraceDqrProfiler::DQErr rc;
+	TraceSettings ts;
+
+	sfp = nullptr;
+	elfReader = nullptr;
+	disassembler = nullptr;
+	caTrace = nullptr;
+	counts = nullptr;//delete this line if compile error
+	efName = nullptr;
+	rtdName = nullptr;
+	cutPath = nullptr;
+	newRoot = nullptr;
+	itcPrint = nullptr;
+	nlsStrings = nullptr;
+	ctf = nullptr;
+	eventConverter = nullptr;
+	perfConverter = nullptr;
+	objdump = nullptr;
+
+	ts.propertyToTFName(tf_name);
+	ts.propertyToEFName(ef_name);
+	ts.propertyToObjdumpName(odExe);
+	ts.numAddrBits = numAddrBits;
+
+	ts.addrDispFlags = addrDispFlags;
+	ts.srcBits = srcBits;
+	ts.freq = freq;
+
+	rc = configure(ts);
+
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		cleanUp();
+	}
+
+	status = rc;
+}
+
+TraceProfiler::~TraceProfiler()
+{
+	cleanUp();
+}
+
+// configure should probably take a options object that contains the seetings for all the options. Easier to add
+// new options that way without the arg list getting unmanageable
+#if 1
+
+TraceDqrProfiler::DQErr TraceProfiler::configure(TraceSettings& settings)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	status = TraceDqrProfiler::DQERR_OK;
+
+	sfp = nullptr;
+	elfReader = nullptr;
+	disassembler = nullptr;
+	caTrace = nullptr;
+	counts = nullptr;//delete this line if compile error
+	efName = nullptr;
+	rtdName = nullptr;
+	cutPath = nullptr;
+	newRoot = nullptr;
+	itcPrint = nullptr;
+	nlsStrings = nullptr;
+	ctf = nullptr;
+	eventConverter = nullptr;
+	eventFilterMask = 0;
+	perfConverter = nullptr;
+	objdump = nullptr;
+
+	syncCount = 0;
+	caSyncAddr = (TraceDqrProfiler::ADDRESS)-1;
+
+	if (settings.odName != nullptr) {
+		int len;
+
+		len = strlen(settings.odName);
+
+		objdump = new char[len + 1];
+
+		strcpy(objdump, settings.odName);
+	}
+	else {
+		objdump = new char[sizeof PROFILER_DEFAULTOBJDUMPNAME + 1];
+		strcpy(objdump, PROFILER_DEFAULTOBJDUMPNAME);
+	}
+
+	//if (settings.tfName == nullptr) {
+	//	printf("Error: TraceProfiler::configure(): No trace file name specified\n");
+	//	status = TraceDqrProfiler::DQERR_ERR;
+
+	//	return TraceDqrProfiler::DQERR_ERR;
+	//}
+
+	traceType = TraceDqrProfiler::TRACETYPE_BTM;
+
+	pathType = settings.pathType;
+
+	srcbits = settings.srcBits;
+
+	if (settings.filterControlEvents) {
+		eventFilterMask = (1 << PROFILER_CTF::et_controlIndex);
+	}
+
+	analytics.setSrcBits(srcbits);
+
+	//rtdName = new char[strlen(settings.tfName) + 1];
+	//strcpy(rtdName, settings.tfName);
+
+	sfp = new (std::nothrow) SliceFileParser(settings.tfName, srcbits);
+
+	if (sfp == nullptr) {
+		printf("Error: TraceProfiler::configure(): Could not create SliceFileParser object\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (sfp->getErr() != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: TraceProfiler::Configure(): Could not open trace file '%s' for input\n", settings.tfName);
+
+		delete sfp;
+		sfp = nullptr;
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	if (settings.efName != nullptr) {
+		int l = strlen(settings.efName) + 1;
+		efName = new char[l];
+		strcpy(efName, settings.efName);
+
+		// create elf object - this also forks off objdump and parses the elf file
+
+		elfReader = new (std::nothrow) ElfReader(settings.efName, objdump);
+
+		if (elfReader == nullptr) {
+			printf("Error: TraceProfiler::Configure(): Could not create ElfReader object\n");
+
+			status = TraceDqrProfiler::DQERR_ERR;
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if (elfReader->getStatus() != TraceDqrProfiler::DQERR_OK) {
+			status = TraceDqrProfiler::DQERR_ERR;
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		// get symbol table
+
+		Symtab* symtab;
+		Section* sections;
+
+		symtab = elfReader->getSymtab();
+		if (symtab == nullptr) {
+			status = TraceDqrProfiler::DQERR_ERR;
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		sections = elfReader->getSections();
+		if (sections == nullptr) {
+			status = TraceDqrProfiler::DQERR_ERR;
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		// create disassembler object
+
+		disassembler = new (std::nothrow) Disassembler(symtab, sections, elfReader->getArchSize());
+		if (disassembler == nullptr) {
+			printf("Error: TraceProfiler::Configure(): Could not creat disassembler object\n");
+
+			status = TraceDqrProfiler::DQERR_ERR;
+
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		if (disassembler->getStatus() != TraceDqrProfiler::DQERR_OK) {
+			status = TraceDqrProfiler::DQERR_ERR;
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		rc = disassembler->setPathType(settings.pathType);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return rc;
+		}
+	}
+	else {
+		elfReader = nullptr;
+		disassembler = nullptr;
+		sfp = nullptr;
+	}
+
+	for (int i = 0; (size_t)i < sizeof lastFaddr / sizeof lastFaddr[0]; i++) {
+		lastFaddr[i] = 0;
+	}
+
+	for (int i = 0; (size_t)i < sizeof currentAddress / sizeof currentAddress[0]; i++) {
+		currentAddress[i] = 0;
+	}
+
+	counts = new Count[DQR_PROFILER_MAXCORES];
+
+	for (int i = 0; (size_t)i < sizeof state / sizeof state[0]; i++) {
+		state[i] = TRACE_STATE_GETFIRSTSYNCMSG;
+	}
+
+	readNewTraceMessage = true;
+	currentCore = 0;	// as good as eny!
+
+	for (int i = 0; (size_t)i < sizeof lastTime / sizeof lastTime[0]; i++) {
+		lastTime[i] = 0;
+	}
+
+	for (int i = 0; (size_t)i < sizeof lastCycle / sizeof lastCycle[0]; i++) {
+		lastCycle[i] = 0;
+	}
+
+	for (int i = 0; (size_t)i < sizeof eCycleCount / sizeof eCycleCount[0]; i++) {
+		eCycleCount[i] = 0;
+	}
+
+	instructionInfo.CRFlag = TraceDqrProfiler::isNone;
+	instructionInfo.brFlags = TraceDqrProfiler::BRFLAG_none;
+
+	instructionInfo.address = 0;
+	instructionInfo.instruction = 0;
+	instructionInfo.instSize = 0;
+
+	if (settings.numAddrBits != 0) {
+		instructionInfo.addrSize = settings.numAddrBits;
+	}
+	else if (elfReader == nullptr) {
+		instructionInfo.addrSize = 0;
+	}
+	else {
+		instructionInfo.addrSize = elfReader->getBitsPerAddress();
+	}
+
+	instructionInfo.addrDispFlags = settings.addrDispFlags;
+
+	instructionInfo.addrPrintWidth = (instructionInfo.addrSize + 3) / 4;
+
+	instructionInfo.addressLabel = nullptr;
+	instructionInfo.addressLabelOffset = 0;
+
+	instructionInfo.timestamp = 0;
+	instructionInfo.caFlags = TraceDqrProfiler::CAFLAG_NONE;
+	instructionInfo.pipeCycles = 0;
+	instructionInfo.VIStartCycles = 0;
+	instructionInfo.VIFinishCycles = 0;
+
+	sourceInfo.sourceFile = nullptr;
+	sourceInfo.sourceFunction = nullptr;
+	sourceInfo.sourceLineNum = 0;
+	sourceInfo.sourceLine = nullptr;
+
+	freq = settings.freq;
+	ProfilerNexusMessage::targetFrequency = settings.freq;
+
+	tsSize = settings.tsSize;
+
+	for (int i = 0; (size_t)i < sizeof enterISR / sizeof enterISR[0]; i++) {
+		enterISR[i] = TraceDqrProfiler::isNone;
+	}
+
+	status = setITCPrintOptions(TraceDqrProfiler::ITC_OPT_NLS, 4096, 0);
+
+	if (settings.itcPrintOpts != TraceDqrProfiler::ITC_OPT_NONE) {
+		rc = setITCPrintOptions(settings.itcPrintOpts, settings.itcPrintBufferSize, settings.itcPrintChannel);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return status;
+		}
+	}
+
+	if ((settings.caName != nullptr) && (settings.caType != TraceDqrProfiler::CATRACE_NONE)) {
+		rc = setCATraceFile(settings.caName, settings.caType);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return status;
+		}
+	}
+
+	if (settings.CTFConversion != false) {
+
+		// Do the code below only after setting efName above
+
+		rc = enableCTFConverter(settings.startTime, settings.hostName);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return status;
+		}
+	}
+
+	if (settings.eventConversionEnable != false) {
+
+		// Do the code below only after setting efName above
+
+		rc = enableEventConverter();
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return status;
+		}
+	}
+
+	if (settings.itcPerfEnable != false) {
+
+		// verify itc print (if enabled) and perf are not using the same channel
+
+		if ((settings.itcPrintChannel == settings.itcPerfChannel) && (settings.itcPrintOpts != TraceDqrProfiler::ITC_OPT_NONE) && (settings.itcPrintOpts != TraceDqrProfiler::ITC_OPT_NLS)) {
+			printf("ITC Print Channel and ITC PerfChannel cannot be the same (%d)\n", settings.itcPrintChannel);
+
+			status = TraceDqrProfiler::DQERR_ERR;
+			return status;
+		}
+
+		// Do the code below only after setting efName above
+
+		int perfChannel;
+		uint32_t markerValue;
+
+		perfChannel = settings.itcPerfChannel;
+		markerValue = settings.itcPerfMarkerValue;
+
+		rc = enablePerfConverter(perfChannel, markerValue);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+			return status;
+		}
+	}
+
+	if ((settings.cutPath != nullptr) || (settings.srcRoot != nullptr)) {
+		rc = subSrcPath(settings.cutPath, settings.srcRoot);
+		if (rc != TraceDqrProfiler::DQERR_OK) {
+			status = rc;
+
+			return status;
+		}
+	}
+
+	return status;
+}
+#endif
+void TraceProfiler::cleanUp()
+{
+	if (objdump != nullptr) {
+		delete[] objdump;
+		objdump = nullptr;
+	}
+
+	for (int i = 0; (size_t)i < (sizeof state / sizeof state[0]); i++) {
+		state[i] = TRACE_STATE_DONE;
+	}
+
+	if (sfp != nullptr) {
+		delete sfp;
+		sfp = nullptr;
+	}
+
+	if (elfReader != nullptr) {
+		delete elfReader;
+		elfReader = nullptr;
+	}
+
+	if (cutPath != nullptr) {
+		delete[] cutPath;
+		cutPath = nullptr;
+	}
+
+	if (newRoot != nullptr) {
+		delete[] newRoot;
+		newRoot = nullptr;
+	}
+
+	if (rtdName != nullptr) {
+		delete[] rtdName;
+		rtdName = nullptr;
+	}
+
+	if (efName != nullptr) {
+		delete[] efName;
+		efName = nullptr;
+	}
+
+	if (itcPrint != nullptr) {
+		delete itcPrint;
+		itcPrint = nullptr;
+	}
+
+	if (nlsStrings != nullptr) {
+		for (int i = 0; i < 32; i++) {
+			if (nlsStrings[i].format != nullptr) {
+				delete[] nlsStrings[i].format;
+				nlsStrings[i].format = nullptr;
+			}
+		}
+
+		delete[] nlsStrings;
+		nlsStrings = nullptr;
+	}
+
+	if (counts != nullptr) {
+		delete[] counts;
+		counts = nullptr;
+	}
+
+	if (disassembler != nullptr) {
+		delete disassembler;
+		disassembler = nullptr;
+	}
+
+	if (caTrace != nullptr) {
+		delete caTrace;
+		caTrace = nullptr;
+	}
+
+	if (ctf != nullptr) {
+		delete ctf;
+		ctf = nullptr;
+	}
+
+	if (eventConverter != nullptr) {
+		delete eventConverter;
+		eventConverter = nullptr;
+	}
+
+	if (perfConverter != nullptr) {
+		delete perfConverter;
+		perfConverter = nullptr;
+	}
+}
+
+const char* TraceProfiler::version()
+{
+	return DQR_PROFILER_VERSION;
+}
+
+int TraceProfiler::decodeInstructionSize(uint32_t inst, int& inst_size)
+{
+	return disassembler->decodeInstructionSize(inst, inst_size);
+}
+
+int TraceProfiler::decodeInstruction(uint32_t instruction, int& inst_size, TraceDqrProfiler::InstType& inst_type, TraceDqrProfiler::Reg& rs1, TraceDqrProfiler::Reg& rd, int32_t& immediate, bool& is_branch)
+{
+	return disassembler->decodeInstruction(instruction, getArchSize(), inst_size, inst_type, rs1, rd, immediate, is_branch);
+}
+
+int TraceProfiler::getArchSize()
+{
+	if (elfReader == nullptr) {
+		return 0;
+	}
+
+	return elfReader->getArchSize();
+}
+
+int TraceProfiler::getAddressSize()
+{
+	if (elfReader == nullptr) {
+		return 0;
+	}
+
+	return elfReader->getBitsPerAddress();
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::setTraceType(TraceDqrProfiler::TraceType tType)
+{
+	switch (tType) {
+	case TraceDqrProfiler::TRACETYPE_BTM:
+	case TraceDqrProfiler::TRACETYPE_HTM:
+		traceType = tType;
+		return TraceDqrProfiler::DQERR_OK;
+	default:
+		break;
+	}
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::setPathType(TraceDqrProfiler::pathType pt)
+{
+	pathType = pt;
+
+	if (disassembler != nullptr) {
+		TraceDqrProfiler::DQErr rc;
+
+		rc = disassembler->setPathType(pt);
+
+		status = rc;
+		return rc;
+	}
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::subSrcPath(const char* cutPath, const char* newRoot)
+{
+	if (this->cutPath != nullptr) {
+		delete[] this->cutPath;
+		this->cutPath = nullptr;
+	}
+
+	if (this->newRoot != nullptr) {
+		delete[] this->newRoot;
+		this->newRoot = nullptr;
+	}
+
+	if (cutPath != nullptr) {
+		int l = strlen(cutPath) + 1;
+
+		this->cutPath = new char[l];
+		strcpy(this->cutPath, cutPath);
+	}
+
+	if (newRoot != nullptr) {
+		int l = strlen(newRoot) + 1;
+
+		this->newRoot = new char[l];
+		strcpy(this->newRoot, newRoot);
+	}
+
+	if (disassembler != nullptr) {
+		TraceDqrProfiler::DQErr rc;
+
+		rc = disassembler->subSrcPath(cutPath, newRoot);
+
+		status = rc;
+		return rc;
+	}
+
+	status = TraceDqrProfiler::DQERR_ERR;
+
+	return TraceDqrProfiler::DQERR_ERR;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::setCATraceFile(char* caf_name, TraceDqrProfiler::CATraceType catype)
+{
+	caTrace = new ProfilerCATrace(caf_name, catype);
+
+	TraceDqrProfiler::DQErr rc;
+	rc = caTrace->getStatus();
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+		return rc;
+	}
+
+	// need to sync up ca trace file and trace file. Here, or in next instruction?
+
+	for (int i = 0; (size_t)i < sizeof state / sizeof state[0]; i++) {
+		state[i] = TRACE_STATE_SYNCCATE;
+	}
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::enableCTFConverter(int64_t startTime, char* hostName)
+{
+	if (ctf != nullptr) {
+		delete ctf;
+		ctf = nullptr;
+	}
+
+	if (efName == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	//ctf = new CTFConverter(efName, rtdName, 1 << srcbits, getArchSize(), freq, startTime, hostName);
+
+	//status = ctf->getStatus();
+	//if (status != TraceDqrProfiler::DQERR_OK) {
+	//	return status;
+	//}
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::enablePerfConverter(int perfChannel, uint32_t markerValue)
+{
+	if (perfConverter != nullptr) {
+		delete perfConverter;
+		perfConverter = nullptr;
+	}
+
+	if (efName == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	//perfConverter = new PerfConverter(efName, rtdName, disassembler, 1 << srcbits, perfChannel, markerValue, freq);
+
+	//status = perfConverter->getStatus();
+	//if (status != TraceDqrProfiler::DQERR_OK) {
+	//	return status;
+	//}
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::enableEventConverter()
+{
+	if (eventConverter != nullptr) {
+		delete eventConverter;
+		eventConverter = nullptr;
+	}
+
+	if (efName == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	//eventConverter = new EventConverter(efName, rtdName, disassembler, 1 << srcbits, freq);
+
+	//status = eventConverter->getStatus();
+	//if (status != TraceDqrProfiler::DQERR_OK) {
+	//	return status;
+	//}
+
+	return status;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::setTSSize(int size)
+{
+	tsSize = size;
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::TIMESTAMP TraceProfiler::processTS(TraceDqrProfiler::tsType tstype, TraceDqrProfiler::TIMESTAMP lastTs, TraceDqrProfiler::TIMESTAMP newTs)
+{
+	TraceDqrProfiler::TIMESTAMP ts;
+
+	if (tstype == TraceDqrProfiler::TS_full) {
+		// add in the wrap from previous timestamps
+		ts = newTs + (lastTs & (~((((TraceDqrProfiler::TIMESTAMP)1) << tsSize) - 1)));
+	}
+	else if (lastTs != 0) {
+		ts = lastTs ^ newTs;
+	}
+	else {
+		ts = 0;
+	}
+
+	if (ts < lastTs) {
+		// adjust for wrap
+		ts += ((TraceDqrProfiler::TIMESTAMP)1) << tsSize;
+	}
+
+	return ts;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::getNumBytesInSWTQ(int& numBytes)
+{
+	if (sfp == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return sfp->getNumBytesInSWTQ(numBytes);
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::getTraceFileOffset(int& size, int& offset)
+{
+	return sfp->getFileOffset(size, offset);
+}
+
+int TraceProfiler::getITCPrintMask()
+{
+	if (itcPrint == nullptr) {
+		return 0;
+	}
+
+	return itcPrint->getITCPrintMask();
+}
+
+int TraceProfiler::getITCFlushMask()
+{
+	if (itcPrint == nullptr) {
+		return 0;
+	}
+
+	return itcPrint->getITCFlushMask();
+}
+
+TraceDqrProfiler::ADDRESS TraceProfiler::computeAddress()
+{
+	switch (nm.tcode) {
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+		break;
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+		break;
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+		//		currentAddress = target of branch.
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		currentAddress[currentCore] = currentAddress[currentCore] ^ (nm.indirectBranch.u_addr << 1);	// note - this is the next address!
+		break;
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+		break;
+	case TraceDqrProfiler::TCODE_DATA_READ:
+		break;
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+		break;
+	case TraceDqrProfiler::TCODE_ERROR:
+		break;
+	case TraceDqrProfiler::TCODE_SYNC:
+		currentAddress[currentCore] = nm.sync.f_addr << 1;
+		break;
+	case TraceDqrProfiler::TCODE_CORRECTION:
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		currentAddress[currentCore] = nm.directBranchWS.f_addr << 1;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		currentAddress[currentCore] = nm.indirectBranchWS.f_addr << 1;
+		break;
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+		break;
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+		break;
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+		break;
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		currentAddress[currentCore] = currentAddress[currentCore] ^ (nm.indirectHistory.u_addr << 1);	// note - this is the next address!
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		currentAddress[currentCore] = nm.indirectHistoryWS.f_addr << 1;
+		break;
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+		break;
+	default:
+		break;
+	}
+
+	std::cout << "New address 0x" << std::hex << currentAddress[currentCore] << std::dec << std::endl;
+
+	return currentAddress[currentCore];
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::Disassemble(TraceDqrProfiler::ADDRESS addr)
+{
+	if (disassembler == nullptr) {
+		printf("Error: TraceProfiler::Disassemble(): No disassembler object\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+
+	rc = disassembler->disassemble(addr);
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		status = rc;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	// the two lines below copy each structure completely. This is probably
+	// pretty inefficient, and just returning pointers and using pointers
+	// would likely be better
+
+	instructionInfo = disassembler->getInstructionInfo();
+	sourceInfo = disassembler->getSourceInfo();
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+//const char *TraceProfiler::getSymbolByAddress(TraceDqrProfiler::ADDRESS addr)
+//{
+//	return symtab->getSymbolByAddress(addr);
+//}
+
+TraceDqrProfiler::DQErr TraceProfiler::setITCPrintOptions(int itcFlags, int buffSize, int channel)
+{
+	if (itcPrint != nullptr) {
+		delete itcPrint;
+		itcPrint = nullptr;
+	}
+
+	if (itcFlags != TraceDqrProfiler::ITC_OPT_NONE) {
+		if ((nlsStrings == nullptr) && (elfReader != nullptr)) {
+			TraceDqrProfiler::DQErr rc;
+
+			nlsStrings = new TraceDqrProfiler::nlStrings[32];
+
+			rc = elfReader->parseNLSStrings(nlsStrings);
+			if (rc != TraceDqrProfiler::DQERR_OK) {
+				status = rc;
+
+				delete[] nlsStrings;
+				nlsStrings = nullptr;
+
+				return rc;
+			}
+		}
+
+		itcPrint = new ITCPrint(itcFlags, 1 << srcbits, buffSize, channel, nlsStrings);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::haveITCPrintData(int numMsgs[DQR_PROFILER_MAXCORES], bool havePrintData[DQR_PROFILER_MAXCORES])
+{
+	if (itcPrint == nullptr) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	itcPrint->haveITCPrintData(numMsgs, havePrintData);
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+bool TraceProfiler::getITCPrintMsg(int core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	if (itcPrint == nullptr) {
+		return false;
+	}
+
+	return itcPrint->getITCPrintMsg(core, dst, dstLen, startTime, endTime);
+}
+
+bool TraceProfiler::flushITCPrintMsg(int core, char* dst, int dstLen, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	if (itcPrint == nullptr) {
+		return false;
+	}
+
+	return itcPrint->flushITCPrintMsg(core, dst, dstLen, startTime, endTime);
+}
+
+std::string TraceProfiler::getITCPrintStr(int core, bool& haveData, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	std::string s = "";
+
+	if (itcPrint == nullptr) {
+		haveData = false;
+	}
+	else {
+		haveData = itcPrint->getITCPrintStr(core, s, startTime, endTime);
+	}
+
+	return s;
+}
+
+std::string TraceProfiler::getITCPrintStr(int core, bool& haveData, double& startTime, double& endTime)
+{
+	std::string s = "";
+	TraceDqrProfiler::TIMESTAMP sts, ets;
+
+	if (itcPrint == nullptr) {
+		haveData = false;
+	}
+	else {
+		haveData = itcPrint->getITCPrintStr(core, s, sts, ets);
+
+		if (haveData != false) {
+			if (ProfilerNexusMessage::targetFrequency != 0) {
+				startTime = ((double)sts) / ProfilerNexusMessage::targetFrequency;
+				endTime = ((double)ets) / ProfilerNexusMessage::targetFrequency;
+			}
+			else {
+				startTime = sts;
+				endTime = ets;
+			}
+		}
+	}
+
+	return s;
+}
+
+std::string TraceProfiler::flushITCPrintStr(int core, bool& haveData, TraceDqrProfiler::TIMESTAMP& startTime, TraceDqrProfiler::TIMESTAMP& endTime)
+{
+	std::string s = "";
+
+	if (itcPrint == nullptr) {
+		haveData = false;
+	}
+	else {
+		haveData = itcPrint->flushITCPrintStr(core, s, startTime, endTime);
+	}
+
+	return s;
+}
+
+std::string TraceProfiler::flushITCPrintStr(int core, bool& haveData, double& startTime, double& endTime)
+{
+	std::string s = "";
+	TraceDqrProfiler::TIMESTAMP sts, ets;
+
+	if (itcPrint == nullptr) {
+		haveData = false;
+	}
+	else {
+		haveData = itcPrint->flushITCPrintStr(core, s, sts, ets);
+
+		if (haveData != false) {
+			if (ProfilerNexusMessage::targetFrequency != 0) {
+				startTime = ((double)sts) / ProfilerNexusMessage::targetFrequency;
+				endTime = ((double)ets) / ProfilerNexusMessage::targetFrequency;
+			}
+			else {
+				startTime = sts;
+				endTime = ets;
+			}
+		}
+	}
+
+	return s;
+}
+
+// This routine only works for event traces! In particular, brFlags will assumes there is an
+// event message at addresses for conditional branches because the branch was taken!
+
+TraceDqrProfiler::DQErr TraceProfiler::getCRBRFlags(TraceDqrProfiler::ICTReason cksrc, TraceDqrProfiler::ADDRESS addr, int& crFlag, int& brFlag)
+{
+	int rc;
+	TraceDqrProfiler::DQErr ec;
+	uint32_t inst;
+	int inst_size;
+	TraceDqrProfiler::InstType inst_type;
+	int32_t immediate;
+	bool isBranch;
+	TraceDqrProfiler::Reg rs1;
+	TraceDqrProfiler::Reg rd;
+
+	//	Need to get the destination of the call, which is in the immediate field
+
+	crFlag = TraceDqrProfiler::isNone;
+	brFlag = TraceDqrProfiler::BRFLAG_none;
+
+	switch (cksrc) {
+	case TraceDqrProfiler::ICT_CONTROL:
+	case TraceDqrProfiler::ICT_EXT_TRIG:
+	case TraceDqrProfiler::ICT_WATCHPOINT:
+	case TraceDqrProfiler::ICT_PC_SAMPLE:
+		break;
+	case TraceDqrProfiler::ICT_INFERABLECALL:
+		ec = elfReader->getInstructionByAddress(addr, inst);
+		if (ec != TraceDqrProfiler::DQERR_OK) {
+			printf("Error: getCRBRFlags() failed\n");
+
+			status = ec;
+			return ec;
+		}
+
+		rc = decodeInstruction(inst, inst_size, inst_type, rs1, rd, immediate, isBranch);
+		if (rc != 0) {
+			printf("Error: getCRBRFlags(): Cann't decode size of instruction %04x\n", inst);
+
+			status = TraceDqrProfiler::DQERR_ERR;
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+
+		switch (inst_type) {
+		case TraceDqrProfiler::INST_JALR:
+			if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+				if ((rs1 != TraceDqrProfiler::REG_1) && (rs1 != TraceDqrProfiler::REG_5)) { // rd == link; rs1 != link
+					crFlag = TraceDqrProfiler::isCall;
+				}
+				else if (rd != rs1) { // rd == link; rs1 == link; rd != rs1
+					crFlag = TraceDqrProfiler::isSwap;
+				}
+				else { // rd == link; rs1 == link; rd == rs1
+					crFlag = TraceDqrProfiler::isCall;
+				}
+			}
+			else if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) { // rd != link; rs1 == link
+				crFlag = TraceDqrProfiler::isReturn;
+			}
+			break;
+		case TraceDqrProfiler::INST_JAL:
+			if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+				crFlag = TraceDqrProfiler::isCall;
+			}
+			break;
+		case TraceDqrProfiler::INST_C_JAL:
+			if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+				crFlag = TraceDqrProfiler::isCall;
+			}
+			break;
+		case TraceDqrProfiler::INST_C_JR:
+			if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) {
+				crFlag = TraceDqrProfiler::isReturn;
+			}
+			break;
+		case TraceDqrProfiler::INST_EBREAK:
+		case TraceDqrProfiler::INST_ECALL:
+			crFlag = TraceDqrProfiler::isException;
+			break;
+		case TraceDqrProfiler::INST_MRET:
+		case TraceDqrProfiler::INST_SRET:
+		case TraceDqrProfiler::INST_URET:
+			crFlag = TraceDqrProfiler::isExceptionReturn;
+			break;
+		case TraceDqrProfiler::INST_BEQ:
+		case TraceDqrProfiler::INST_BNE:
+		case TraceDqrProfiler::INST_BLT:
+		case TraceDqrProfiler::INST_BGE:
+		case TraceDqrProfiler::INST_BLTU:
+		case TraceDqrProfiler::INST_BGEU:
+		case TraceDqrProfiler::INST_C_BEQZ:
+		case TraceDqrProfiler::INST_C_BNEZ:
+			brFlag = TraceDqrProfiler::BRFLAG_taken;
+			break;
+		default:
+			break;
+		}
+		break;
+	case TraceDqrProfiler::ICT_EXCEPTION:
+		crFlag = TraceDqrProfiler::isException;
+		break;
+	case TraceDqrProfiler::ICT_INTERRUPT:
+		crFlag = TraceDqrProfiler::isInterrupt;
+		break;
+	case TraceDqrProfiler::ICT_CONTEXT:
+		crFlag = TraceDqrProfiler::isSwap;
+		break;
+	default:
+		printf("Error: getCRBRFlags(): Invalid crsrc\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+// Note: This next instruction only computes nextAddr for inferable calls. It does set the crFlag
+// correctly for others.
+
+TraceDqrProfiler::DQErr TraceProfiler::nextAddr(TraceDqrProfiler::ADDRESS addr, TraceDqrProfiler::ADDRESS& nextAddr, int& crFlag)
+{
+	int rc;
+	TraceDqrProfiler::DQErr ec;
+	uint32_t inst;
+	int inst_size;
+	TraceDqrProfiler::InstType inst_type;
+	int32_t immediate;
+	bool isBranch;
+	TraceDqrProfiler::Reg rs1;
+	TraceDqrProfiler::Reg rd;
+
+	ec = elfReader->getInstructionByAddress(addr, inst);
+	if (ec != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: nextAddr() failed\n");
+
+		status = ec;
+		return ec;
+	}
+
+	//	Need to get the destination of the call, which is in the immediate field
+
+	crFlag = TraceDqrProfiler::isNone;
+	nextAddr = 0;
+
+	rc = decodeInstruction(inst, inst_size, inst_type, rs1, rd, immediate, isBranch);
+	if (rc != 0) {
+		printf("Error: Cann't decode size of instruction %04x\n", inst);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	switch (inst_type) {
+	case TraceDqrProfiler::INST_JALR:
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			if ((rs1 != TraceDqrProfiler::REG_1) && (rs1 != TraceDqrProfiler::REG_5)) { // rd == link; rs1 != link
+				crFlag |= TraceDqrProfiler::isCall;
+			}
+			else if (rd != rs1) { // rd == link; rs1 == link; rd != rs1
+				crFlag |= TraceDqrProfiler::isSwap;
+			}
+			else { // rd == link; rs1 == link; rd == rs1
+				crFlag |= TraceDqrProfiler::isCall;
+			}
+		}
+		else if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) { // rd != link; rs1 == link
+			crFlag |= TraceDqrProfiler::isReturn;
+		}
+		break;
+	case TraceDqrProfiler::INST_JAL:
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			crFlag = TraceDqrProfiler::isCall;
+		}
+
+		nextAddr = addr + immediate;
+		break;
+	case TraceDqrProfiler::INST_C_JAL:
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			crFlag = TraceDqrProfiler::isCall;
+		}
+
+		nextAddr = addr + immediate;
+		break;
+	case TraceDqrProfiler::INST_C_JR:
+		// pc = pc + rs1
+		// not inferrable unconditional
+
+		if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) {
+			crFlag |= TraceDqrProfiler::isReturn;
+		}
+		break;
+	case TraceDqrProfiler::INST_C_JALR:
+		if (rs1 == TraceDqrProfiler::REG_5) { // is it reg5 only, or also reg1 like non-compact JALR?
+			crFlag |= TraceDqrProfiler::isSwap;
+		}
+		else {
+			crFlag |= TraceDqrProfiler::isCall;
+		}
+		break;
+	case TraceDqrProfiler::INST_EBREAK:
+	case TraceDqrProfiler::INST_ECALL:
+		crFlag = TraceDqrProfiler::isException;
+		break;
+	case TraceDqrProfiler::INST_MRET:
+	case TraceDqrProfiler::INST_SRET:
+	case TraceDqrProfiler::INST_URET:
+		crFlag = TraceDqrProfiler::isExceptionReturn;
+		break;
+	default:
+		printf("Error: TraceProfiler::nextAddr(): ProfilerInstruction at 0x%08x is not a JAL, JALR, C_JAL, C_JR, C_JALR, EBREAK, ECALL, MRET, SRET, or URET\n", addr);
+
+#ifdef foodog
+		printf("ProfilerInstruction type: %d\n", inst_type);
+
+		// disassemble and display instruction
+
+		Disassemble(addr);
+
+		char dst[256];
+		instructionInfo.addressToText(dst, sizeof dst, 0);
+
+		if (instructionInfo.addressLabel != nullptr) {
+			printf("<%s", instructionInfo.addressLabel);
+			if (instructionInfo.addressLabelOffset != 0) {
+				printf("+%x", instructionInfo.addressLabelOffset);
+			}
+			printf(">\n");
+		}
+
+		printf("    %s:    ", dst);
+
+		instructionInfo.instructionToText(dst, sizeof dst, 2);
+		printf("  %s\n", dst);
+#endif // foodog
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+// this function takes the starting address and runs one instruction only!!
+// The result is the address it stops at. It also consumes the counts (i-cnt,
+// history, taken, not-taken) when appropriate!
+
+TraceDqrProfiler::DQErr TraceProfiler::nextAddr(int core, TraceDqrProfiler::ADDRESS addr, TraceDqrProfiler::ADDRESS& pc, TraceDqrProfiler::TCode tcode, int& crFlag, TraceDqrProfiler::BranchFlags& brFlag)
+{
+	TraceDqrProfiler::CountType ct;
+	uint32_t inst;
+	int inst_size;
+	TraceDqrProfiler::InstType inst_type;
+	int32_t immediate;
+	bool isBranch;
+	int rc;
+	TraceDqrProfiler::Reg rs1;
+	TraceDqrProfiler::Reg rd;
+	bool isTaken;
+
+	status = elfReader->getInstructionByAddress(addr, inst);
+	if (status != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: nextAddr(): getInstructionByAddress() failed\n");
+
+		return status;
+	}
+
+	crFlag = TraceDqrProfiler::isNone;
+	brFlag = TraceDqrProfiler::BRFLAG_none;
+
+	// figure out how big the instruction is
+	// Note: immediate will already be adjusted - don't need to mult by 2 before adding to address
+
+	rc = decodeInstruction(inst, inst_size, inst_type, rs1, rd, immediate, isBranch);
+	if (rc != 0) {
+		printf("Error: nextAddr(): Cannot decode instruction %04x\n", inst);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return status;
+	}
+
+	switch (inst_type) {
+	case TraceDqrProfiler::INST_UNKNOWN:
+		// btm and htm same
+
+		pc = addr + inst_size / 8;
+		break;
+	case TraceDqrProfiler::INST_JAL:
+		// btm and htm same
+
+		// rd = pc+4 (rd can be r0)
+		// pc = pc + (sign extended immediate offset)
+		// plan unconditional jumps use rd -> r0
+		// inferrable unconditional
+
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			counts->push(core, addr + inst_size / 8);
+			if (profiler_globalDebugFlag) printf("Debug: call: core %d, pushing address %08llx, %d item now on stack\n", core, addr + inst_size / 8, counts->getNumOnStack(core));
+			crFlag |= TraceDqrProfiler::isCall;
+		}
+
+		pc = addr + immediate;
+		break;
+	case TraceDqrProfiler::INST_JALR:
+		// btm: indirect branch; return pc = -1
+		// htm: indirect branch with history; return pc = pop'd addr if possible, else -1
+
+		// rd = pc+4 (rd can be r0)
+		// pc = pc + ((sign extended immediate offset) + rs) & 0xffe
+		// plain unconditional jumps use rd -> r0
+		// not inferrable unconditional
+
+//		printf("rd: %d, rs1: %d, reg_1: %d, reg_5: %d\n",rd,rs1,TraceDqrProfiler::REG_1,TraceDqrProfiler::REG_5);
+
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			if ((rs1 != TraceDqrProfiler::REG_1) && (rs1 != TraceDqrProfiler::REG_5)) { // rd == link; rs1 != link
+				counts->push(core, addr + inst_size / 8);
+				if (profiler_globalDebugFlag) printf("Debug: indirect call: core %d, pushing address %08llx, %d item now on stack\n", core, addr + inst_size / 8, counts->getNumOnStack(core));
+				pc = -1;
+				crFlag |= TraceDqrProfiler::isCall;
+			}
+			else if (rd != rs1) { // rd == link; rs1 == link; rd != rs1
+				pc = counts->pop(core);
+				counts->push(core, addr + inst_size / 8);
+				if (profiler_globalDebugFlag) printf("Debug: indirect call: core %d, pushing address %08llx, %d item now on stack\n", core, addr + inst_size / 8, counts->getNumOnStack(core));
+				crFlag |= TraceDqrProfiler::isSwap;
+			}
+			else { // rd == link; rs1 == link; rd == rs1
+				counts->push(core, addr + inst_size / 8);
+				if (profiler_globalDebugFlag) printf("Debug: indirect call: core %d, pushing address %08llx, %d item now on stack\n", core, addr + inst_size / 8, counts->getNumOnStack(core));
+				pc = -1;
+				crFlag |= TraceDqrProfiler::isCall;
+			}
+		}
+		else if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) { // rd != link; rs1 == link
+			pc = counts->pop(core);
+			if (profiler_globalDebugFlag) printf("Debug: return: core %d, new address %08llx, %d item now on stack\n", core, pc, counts->getNumOnStack(core));
+			crFlag |= TraceDqrProfiler::isReturn;
+		}
+		else {
+			pc = -1;
+		}
+
+		// Try to tell if this is a btm or htm based on counts and isReturn | isSwap
+
+		if (traceType == TraceDqrProfiler::TRACETYPE_BTM) {
+			if (crFlag & (TraceDqrProfiler::isReturn | TraceDqrProfiler::isSwap)) {
+				if (counts->consumeICnt(core, 0) > inst_size / 16) {
+					traceType = TraceDqrProfiler::TRACETYPE_HTM;
+					if (profiler_globalDebugFlag) printf("JALR: switching to HTM trace\n");
+				}
+			}
+		}
+
+		if (traceType == TraceDqrProfiler::TRACETYPE_BTM) {
+			if (counts->consumeICnt(core, 0) > inst_size / 16) {
+				// this handles the case of jumping to the instruction following the jump!
+
+				pc = addr + inst_size / 8;
+			}
+			else {
+				pc = -1;
+			}
+		}
+		break;
+	case TraceDqrProfiler::INST_BEQ:
+	case TraceDqrProfiler::INST_BNE:
+	case TraceDqrProfiler::INST_BLT:
+	case TraceDqrProfiler::INST_BGE:
+	case TraceDqrProfiler::INST_BLTU:
+	case TraceDqrProfiler::INST_BGEU:
+	case TraceDqrProfiler::INST_C_BEQZ:
+	case TraceDqrProfiler::INST_C_BNEZ:
+		// htm: follow history bits
+		// btm: there will only be a trace record following this for taken branch. not taken branches are not
+		// reported. If btm mode, we can look at i-count. If it is going to go to 0, branch was taken (direct branch message
+		// will follow). If not going to 0, not taken
+
+		// pc = pc + (sign extend immediate offset) (BLTU and BGEU are not sign extended)
+		// inferrable conditional
+
+		if (traceType == TraceDqrProfiler::TRACETYPE_HTM) {
+			// htm mode
+			ct = counts->getCurrentCountType(core);
+			switch (ct) {
+			case TraceDqrProfiler::COUNTTYPE_none:
+				printf("Error: nextAddr(): instruction counts consumed\n");
+
+				return TraceDqrProfiler::DQERR_ERR;
+			case TraceDqrProfiler::COUNTTYPE_i_cnt:
+				if (profiler_globalDebugFlag) printf("Debug: Conditional branch: No history. I-cnt: %d\n", counts->getICnt(core));
+
+				// don't know if the branch is taken or not, so we don't know the next addr
+
+				// This can happen with resource full messages where an i-cnt type resource full
+				// may be emitted by the encoder due to i-cnt overflow, and it still have non-emitted
+				// history bits. We will need to keep reading trace messages until we get a some
+				// history. The current trace message should be retired.
+
+				// this is not an error. Just keep retrying until we get a trace message that
+				// kicks things loose again
+
+				pc = -1;
+
+				// The caller can detect this has happened and read a new trace message and retry, by
+				// checking the brFlag for BRFLAG_unkown
+
+				brFlag = TraceDqrProfiler::BRFLAG_unknown;
+				break;
+			case TraceDqrProfiler::COUNTTYPE_history:
+				//consume history bit here and set pc accordingly
+
+				if (profiler_globalDebugFlag) printf("Debug: Conditional branch: Have history, taken mask: %08x, bit %d, taken: %d\n", counts->getHistory(core), counts->getNumHistoryBits(core), counts->isTaken(core));
+
+				rc = counts->consumeHistory(core, isTaken);
+				if (rc != 0) {
+					printf("Error: nextAddr(): consumeHistory() failed\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+
+					return status;
+				}
+
+				if (isTaken) {
+					pc = addr + immediate;
+					brFlag = TraceDqrProfiler::BRFLAG_taken;
+				}
+				else {
+					pc = addr + inst_size / 8;
+					brFlag = TraceDqrProfiler::BRFLAG_notTaken;
+				}
+				break;
+			case TraceDqrProfiler::COUNTTYPE_taken:
+				if (profiler_globalDebugFlag) printf("Debug: Conditional branch: Have takenCount: %d, taken: %d\n", counts->getTakenCount(core), counts->getTakenCount(core) > 0);
+
+				rc = counts->consumeTakenCount(core);
+				if (rc != 0) {
+					printf("Error: nextAddr(): consumeTakenCount() failed\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+
+					return status;
+				}
+
+				pc = addr + immediate;
+				brFlag = TraceDqrProfiler::BRFLAG_taken;
+				break;
+			case TraceDqrProfiler::COUNTTYPE_notTaken:
+				if (profiler_globalDebugFlag) printf("Debug: Conditional branch: Have notTakenCount: %d, not taken: %d\n", counts->getNotTakenCount(core), counts->getNotTakenCount(core) > 0);
+
+				rc = counts->consumeNotTakenCount(core);
+				if (rc != 0) {
+					printf("Error: nextAddr(): consumeTakenCount() failed\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+
+					return status;
+				}
+
+				pc = addr + inst_size / 8;
+				brFlag = TraceDqrProfiler::BRFLAG_notTaken;
+				break;
+			}
+		}
+		else {
+			// btm mode
+
+			// if i-cnts don't go to zero for this instruction, this branch is not taken in btmmode.
+			// if i-cnts go to zero for this instruciotn, it might be a taken branch. Need to look
+			// at the tcode for the current nexus message. If it is a direct branch with or without
+			// sync, it is taken. Otherwise, not taken (it could be the result of i-cnt reaching the
+			// limit, forcing a sync type message, but branch not taken).
+
+			if (counts->consumeICnt(core, 0) > inst_size / 16) {
+				// not taken
+
+				pc = addr + inst_size / 8;
+
+				brFlag = TraceDqrProfiler::BRFLAG_notTaken;
+			}
+			else if ((tcode == TraceDqrProfiler::TCODE_DIRECT_BRANCH) || (tcode == TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS)) {
+				// taken
+
+				pc = addr + immediate;
+
+				brFlag = TraceDqrProfiler::BRFLAG_taken;
+			}
+			else {
+				// not taken
+
+				pc = addr + inst_size / 8;
+
+				brFlag = TraceDqrProfiler::BRFLAG_notTaken;
+			}
+		}
+		break;
+	case TraceDqrProfiler::INST_C_J:
+		// btm, htm same
+
+		// pc = pc + (signed extended immediate offset)
+		// inferrable unconditional
+
+		pc = addr + immediate;
+		break;
+	case TraceDqrProfiler::INST_C_JAL:
+		// btm, htm same
+
+		// x1 = pc + 2
+		// pc = pc + (signed extended immediate offset)
+		// inferrable unconditional
+
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			counts->push(core, addr + inst_size / 8);
+			if (profiler_globalDebugFlag) printf("Debug: call: core %d, pushing address %08llx, %d item now on stack\n", core, addr + inst_size / 8, counts->getNumOnStack(core));
+			crFlag |= TraceDqrProfiler::isCall;
+		}
+
+		pc = addr + immediate;
+		break;
+	case TraceDqrProfiler::INST_C_JR:
+		// pc = pc + rs1
+		// not inferrable unconditional
+
+		if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) {
+			pc = counts->pop(core);
+			if (profiler_globalDebugFlag) printf("Debug: return: core %d, new address %08llx, %d item now on stack\n", core, pc, counts->getNumOnStack(core));
+			crFlag |= TraceDqrProfiler::isReturn;
+		}
+		else {
+			pc = -1;
+		}
+
+		// Try to tell if this is a btm or htm based on counts and isReturn
+
+		if (traceType == TraceDqrProfiler::TRACETYPE_BTM) {
+			if (crFlag & TraceDqrProfiler::isReturn) {
+				if (counts->consumeICnt(core, 0) > inst_size / 16) {
+					traceType = TraceDqrProfiler::TRACETYPE_HTM;
+					if (profiler_globalDebugFlag) printf("C_JR: switching to HTM trace\n");
+				}
+			}
+		}
+
+		if (traceType == TraceDqrProfiler::TRACETYPE_BTM) {
+			if (counts->consumeICnt(core, 0) > inst_size / 16) {
+				// this handles the case of jumping to the instruction following the jump!
+
+				pc = addr + inst_size / 8;
+			}
+			else {
+				pc = -1;
+			}
+		}
+		break;
+	case TraceDqrProfiler::INST_C_JALR:
+		// x1 = pc + 2
+		// pc = pc + rs1
+		// not inferrble unconditional
+
+		if (rs1 == TraceDqrProfiler::REG_5) {
+			pc = counts->pop(core);
+			counts->push(core, addr + inst_size / 8);
+			if (profiler_globalDebugFlag) printf("Debug: return/call: core %d, new address %08llx, pushing %08xllx, %d item now on stack\n", core, pc, addr + inst_size / 8, counts->getNumOnStack(core));
+			crFlag |= TraceDqrProfiler::isSwap;
+		}
+		else {
+			counts->push(core, addr + inst_size / 8);
+			if (profiler_globalDebugFlag) printf("Debug: call: core %d, new address %08llx (don't know dst yet), pushing %08llx, %d item now on stack\n", core, pc, addr + inst_size / 8, counts->getNumOnStack(core));
+			pc = -1;
+			crFlag |= TraceDqrProfiler::isCall;
+		}
+
+		// Try to tell if this is a btm or htm based on counts and isSwap
+
+		if (traceType == TraceDqrProfiler::TRACETYPE_BTM) {
+			if (crFlag & TraceDqrProfiler::isSwap) {
+				if (counts->consumeICnt(core, 0) > inst_size / 16) {
+					traceType = TraceDqrProfiler::TRACETYPE_HTM;
+					if (profiler_globalDebugFlag) printf("C_JALR: switching to HTM trace\n");
+				}
+			}
+		}
+
+		if (traceType == TraceDqrProfiler::TRACETYPE_BTM) {
+			if (counts->consumeICnt(core, 0) > inst_size / 16) {
+				// this handles the case of jumping to the instruction following the jump!
+
+				pc = addr + inst_size / 8;
+			}
+			else {
+				pc = -1;
+			}
+		}
+		break;
+	case TraceDqrProfiler::INST_EBREAK:
+	case TraceDqrProfiler::INST_ECALL:
+		crFlag |= TraceDqrProfiler::isException;
+		pc = -1;
+		break;
+	case TraceDqrProfiler::INST_MRET:
+	case TraceDqrProfiler::INST_SRET:
+	case TraceDqrProfiler::INST_URET:
+		crFlag |= TraceDqrProfiler::isExceptionReturn;
+		pc = -1;
+		break;
+	default:
+		pc = addr + inst_size / 8;
+		break;
+	}
+
+	// Always consume i-cnt unless brFlag == BRFLAG_unknown because we will retry computing next
+	// addr for this instruction later
+
+	if (brFlag != TraceDqrProfiler::BRFLAG_unknown) {
+		counts->consumeICnt(core, inst_size / 16);
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::nextCAAddr(TraceDqrProfiler::ADDRESS& addr, TraceDqrProfiler::ADDRESS& savedAddr)
+{
+	uint32_t inst;
+	int inst_size;
+	TraceDqrProfiler::InstType inst_type;
+	int32_t immediate;
+	bool isBranch;
+	int rc;
+	TraceDqrProfiler::Reg rs1;
+	TraceDqrProfiler::Reg rd;
+	//	bool isTaken;
+
+		// note: since saveAddr is a single address, we are only implementing a one address stack (not much of a stack)
+
+	status = elfReader->getInstructionByAddress(addr, inst);
+	if (status != TraceDqrProfiler::DQERR_OK) {
+		printf("Error: nextCAAddr(): getInstructionByAddress() failed\n");
+
+		return status;
+	}
+
+	// figure out how big the instruction is
+	// Note: immediate will already be adjusted - don't need to mult by 2 before adding to address
+
+	rc = decodeInstruction(inst, inst_size, inst_type, rs1, rd, immediate, isBranch);
+	if (rc != 0) {
+		printf("Error: nextCAAddr(): Cannot decode instruction %04x\n", inst);
+
+		status = TraceDqrProfiler::DQERR_ERR;
+
+		return status;
+	}
+
+	switch (inst_type) {
+	case TraceDqrProfiler::INST_UNKNOWN:
+		addr = addr + inst_size / 8;
+		break;
+	case TraceDqrProfiler::INST_JAL:
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			savedAddr = addr + inst_size / 8;
+		}
+
+		addr = addr + immediate;
+		break;
+	case TraceDqrProfiler::INST_JALR:
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			if ((rs1 != TraceDqrProfiler::REG_1) && (rs1 != TraceDqrProfiler::REG_5)) { // rd == link; rs1 != link
+				savedAddr = addr + inst_size / 8;
+				addr = -1;
+			}
+			else if (rd != rs1) { // rd == link; rs1 == link; rd != rs1
+				addr = savedAddr;
+				savedAddr = -1;
+			}
+			else { // rd == link; rs1 == link; rd == rs1
+				savedAddr = addr + inst_size / 8;
+				addr = -1;
+			}
+		}
+		else if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) { // rd != link; rs1 == link
+			addr = savedAddr;
+			savedAddr = -1;
+		}
+		else {
+			addr = -1;
+		}
+		break;
+	case TraceDqrProfiler::INST_BEQ:
+	case TraceDqrProfiler::INST_BNE:
+	case TraceDqrProfiler::INST_BLT:
+	case TraceDqrProfiler::INST_BGE:
+	case TraceDqrProfiler::INST_BLTU:
+	case TraceDqrProfiler::INST_BGEU:
+	case TraceDqrProfiler::INST_C_BEQZ:
+	case TraceDqrProfiler::INST_C_BNEZ:
+		if ((addr + inst_size / 8) == (addr + immediate)) {
+			addr += immediate;
+		}
+		else {
+			addr = -1;
+		}
+		break;
+	case TraceDqrProfiler::INST_C_J:
+		addr += immediate;
+		break;
+	case TraceDqrProfiler::INST_C_JAL:
+		if ((rd == TraceDqrProfiler::REG_1) || (rd == TraceDqrProfiler::REG_5)) { // rd == link
+			savedAddr = addr + inst_size / 8;
+		}
+
+		addr += immediate;
+		break;
+	case TraceDqrProfiler::INST_C_JR:
+		if ((rs1 == TraceDqrProfiler::REG_1) || (rs1 == TraceDqrProfiler::REG_5)) {
+			addr = savedAddr;
+			savedAddr = -1;
+		}
+		else {
+			addr = -1;
+		}
+		break;
+	case TraceDqrProfiler::INST_C_JALR:
+		if (rs1 == TraceDqrProfiler::REG_5) {
+			TraceDqrProfiler::ADDRESS taddr;
+
+			// swap addr, saveAddr
+			taddr = addr;
+			addr = savedAddr;
+			savedAddr = taddr;
+		}
+		else {
+			savedAddr = addr + inst_size / 8;
+			addr = -1;
+		}
+		break;
+	case TraceDqrProfiler::INST_EBREAK:
+	case TraceDqrProfiler::INST_ECALL:
+		addr = -1;
+		break;
+	case TraceDqrProfiler::INST_MRET:
+	case TraceDqrProfiler::INST_SRET:
+	case TraceDqrProfiler::INST_URET:
+		addr = -1;
+		break;
+	default:
+		addr += inst_size / 8;
+		break;
+	}
+
+	if (addr == (TraceDqrProfiler::ADDRESS)-1) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+// adjust pc, faddr, timestamp based on faddr, uaddr, timestamp, and message type.
+// Do not adjust counts! They are handled elsewhere
+TraceDqrProfiler::DQErr TraceProfiler::PushTraceData(uint8_t *p_buff, const uint64_t size)
+{
+    return sfp ? sfp->PushTraceData(p_buff, size) : TraceDqrProfiler::DQERR_ERR;
+}
+
+void TraceProfiler::SetEndOfData()
+{
+   if(sfp)
+       sfp->SetEndOfData();
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::processTraceMessage(ProfilerNexusMessage& nm, TraceDqrProfiler::ADDRESS& pc, TraceDqrProfiler::ADDRESS& faddr, TraceDqrProfiler::TIMESTAMP& ts, bool& consumed)
+{
+	consumed = false;
+
+	switch (nm.tcode) {
+	case TraceDqrProfiler::TCODE_ERROR:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_rel, ts, nm.timestamp);
+		}
+
+		// set addrs to 0 because we have dropped some messages and don't know what is going on
+
+		faddr = 0;
+		pc = 0;
+		break;
+	case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_rel, ts, nm.timestamp);
+		}
+
+		if (perfConverter != nullptr) { // or should this be a general itc process thing?? could we process all itc messages here?
+			TraceDqrProfiler::DQErr rc;
+			//rc = perfConverter->processITCPerf(nm.coreId, ts, nm.dataAcquisition.idTag, nm.dataAcquisition.data, consumed);
+			//if (rc != TraceDqrProfiler::DQERR_OK) {
+			//	return rc;
+			//}
+		}
+		break;
+	case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+	case TraceDqrProfiler::TCODE_RESOURCEFULL:
+	case TraceDqrProfiler::TCODE_CORRELATION:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_rel, ts, nm.timestamp);
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_rel, ts, nm.timestamp);
+		}
+		faddr = faddr ^ (nm.indirectBranch.u_addr << 1);
+		pc = faddr;
+		break;
+	case TraceDqrProfiler::TCODE_SYNC:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_full, ts, nm.timestamp);
+		}
+		faddr = nm.sync.f_addr << 1;
+		pc = faddr;
+		counts->resetStack(nm.coreId);
+		counts->resetCounts(nm.coreId);
+		break;
+	case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_full, ts, nm.timestamp);
+		}
+		faddr = nm.directBranchWS.f_addr << 1;
+		pc = faddr;
+		counts->resetStack(nm.coreId);
+		counts->resetCounts(nm.coreId);
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_full, ts, nm.timestamp);
+		}
+		faddr = nm.indirectBranchWS.f_addr << 1;
+		pc = faddr;
+		counts->resetStack(nm.coreId);
+		counts->resetCounts(nm.coreId);
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_rel, ts, nm.timestamp);
+		}
+		faddr = faddr ^ (nm.indirectHistory.u_addr << 1);
+		pc = faddr;
+		break;
+	case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_full, ts, nm.timestamp);
+		}
+		faddr = nm.indirectHistoryWS.f_addr << 1;
+		pc = faddr;
+		counts->resetStack(nm.coreId);
+		counts->resetCounts(nm.coreId);
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+		// for 8, 0; 14, 0 do not update pc, only faddr. 0, 0 has no address, so it never updates
+		// this is because those message types all appear in instruction traces (non-event) and
+		// do not want to update the current address because they have no icnt to say when to do it
+
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_rel, ts, nm.timestamp);
+		}
+
+		switch (nm.ict.cksrc) {
+		case TraceDqrProfiler::ICT_EXT_TRIG:
+			if (nm.ict.ckdf == 0) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				// don't update pc
+
+				//if (eventConverter != nullptr) {
+				//	eventConverter->emitExtTrigEvent(nm.coreId, ts, nm.ict.ckdf, faddr, 0);
+				//}
+			}
+			else if (nm.ict.ckdf == 1) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				pc = faddr;
+
+				//if (eventConverter != nullptr) {
+				//	eventConverter->emitExtTrigEvent(nm.coreId, ts, nm.ict.ckdf, faddr, nm.ict.ckdata[1]);
+				//}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		case TraceDqrProfiler::ICT_WATCHPOINT:
+			if (nm.ict.ckdf == 0) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				// don't update pc
+
+				//if (eventConverter != nullptr) {
+				//	eventConverter->emitWatchpoint(nm.coreId, ts, nm.ict.ckdf, faddr, 0);
+				//}
+			}
+			else if (nm.ict.ckdf == 1) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				pc = faddr;
+
+				//if (eventConverter != nullptr) {
+				//	eventConverter->emitWatchpoint(nm.coreId, ts, nm.ict.ckdf, faddr, nm.ict.ckdata[1]);
+				//}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		case TraceDqrProfiler::ICT_INFERABLECALL:
+			if (nm.ict.ckdf == 0) {
+				pc = faddr ^ (nm.ict.ckdata[0] << 1);
+				faddr = pc;
+
+				TraceDqrProfiler::DQErr rc;
+				TraceDqrProfiler::ADDRESS nextPC;
+				int crFlags;
+
+				rc = nextAddr(pc, nextPC, crFlags);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: processTraceMessage(): Could not compute next address for PROFILER_CTF conversion\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				// we will store the target address back in ckdata[1] in case it is needed later
+
+				nm.ict.ckdata[1] = nextPC;
+
+				if (ctf != nullptr) {
+					//ctf->addCall(nm.coreId, pc, nextPC, ts);
+				}
+
+				//if (eventConverter != nullptr) {
+				//	eventConverter->emitCallRet(nm.coreId, ts, nm.ict.ckdf, pc, nm.ict.ckdata[1], TraceDqrProfiler::isCall);
+				//}
+			}
+			else if (nm.ict.ckdf == 1) {
+				pc = faddr ^ (nm.ict.ckdata[0] << 1);
+				faddr = pc ^ (nm.ict.ckdata[1] << 1);
+
+				if ((ctf != nullptr) || (eventConverter != nullptr)) {
+					TraceDqrProfiler::DQErr rc;
+					TraceDqrProfiler::ADDRESS nextPC;
+					int crFlags;
+
+					rc = nextAddr(pc, nextPC, crFlags);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: processTraceMessage(): Could not compute next address for PROFILER_CTF conversion\n");
+						return TraceDqrProfiler::DQERR_ERR;
+					}
+
+					if (ctf != nullptr) {
+						if (crFlags & TraceDqrProfiler::isCall) {
+							//ctf->addCall(nm.coreId, pc, faddr, ts);
+						}
+						else if ((crFlags & TraceDqrProfiler::isReturn) || (crFlags & TraceDqrProfiler::isExceptionReturn)) {
+							//ctf->addRet(nm.coreId, pc, faddr, ts);
+						}
+						else {
+							printf("Error: processTraceMEssage(): Unsupported crFlags in PROFILER_CTF conversion\n");
+							return TraceDqrProfiler::DQERR_ERR;
+						}
+					}
+
+					//if (eventConverter != nullptr) {
+					//	eventConverter->emitCallRet(nm.coreId, ts, nm.ict.ckdf, pc, faddr, crFlags);
+					//}
+				}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		case TraceDqrProfiler::ICT_EXCEPTION:
+			if (nm.ict.ckdf == 1) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitException(nm.coreId, ts, nm.ict.ckdf, pc, nm.ict.ckdata[1]);
+			}
+			break;
+		case TraceDqrProfiler::ICT_INTERRUPT:
+			if (nm.ict.ckdf == 1) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitInterrupt(nm.coreId, ts, nm.ict.ckdf, pc, nm.ict.ckdata[1]);
+			}
+			break;
+		case TraceDqrProfiler::ICT_CONTEXT:
+			if (nm.ict.ckdf == 1) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitContext(nm.coreId, ts, nm.ict.ckdf, pc, nm.ict.ckdata[1]);
+			}
+			break;
+		case TraceDqrProfiler::ICT_PC_SAMPLE:
+			if (nm.ict.ckdf == 0) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitPeriodic(nm.coreId, ts, nm.ict.ckdf, pc);
+			}
+			break;
+		case TraceDqrProfiler::ICT_CONTROL:
+			if (nm.ict.ckdf == 0) {
+				// nothing to do - no address
+				// does not update faddr or pc!
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitControl(nm.coreId, ts, nm.ict.ckdf, nm.ict.ckdata[0], 0);
+				}
+			}
+			else if (nm.ict.ckdf == 1) {
+				faddr = faddr ^ (nm.ict.ckdata[0] << 1);
+				pc = faddr;
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitControl(nm.coreId, ts, nm.ict.ckdf, nm.ict.ckdata[1], pc);
+				}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ict.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		default:
+			printf("Error: processTraceMessage(): Invalid ICT Event: %d\n", nm.ict.cksrc);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+		// for 8, 0; 14, 0 do not update pc, only faddr. 0, 0 has no address, so it never updates
+		// this is because those message types all apprear in instruction traces (non-event) and
+		// do not want to update the current address because they have no icnt to say when to do it
+
+		if (nm.haveTimestamp) {
+			ts = processTS(TraceDqrProfiler::TS_full, ts, nm.timestamp);
+		}
+
+		switch (nm.ictWS.cksrc) {
+		case TraceDqrProfiler::ICT_EXT_TRIG:
+			if (nm.ictWS.ckdf == 0) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				// don't update pc
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitExtTrigEvent(nm.coreId, ts, nm.ictWS.ckdf, faddr, 0);
+				}
+			}
+			else if (nm.ictWS.ckdf == 1) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				pc = faddr;
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitExtTrigEvent(nm.coreId, ts, nm.ictWS.ckdf, faddr, nm.ictWS.ckdata[1]);
+				}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		case TraceDqrProfiler::ICT_WATCHPOINT:
+			if (nm.ictWS.ckdf == 0) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				// don'tupdate pc
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitWatchpoint(nm.coreId, ts, nm.ictWS.ckdf, faddr, 0);
+				}
+			}
+			else if (nm.ictWS.ckdf <= 1) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				pc = faddr;
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitWatchpoint(nm.coreId, ts, nm.ictWS.ckdf, faddr, nm.ictWS.ckdata[1]);
+				}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		case TraceDqrProfiler::ICT_INFERABLECALL:
+			if (nm.ictWS.ckdf == 0) {
+				pc = nm.ictWS.ckdata[0] << 1;
+				faddr = pc;
+
+				TraceDqrProfiler::DQErr rc;
+				TraceDqrProfiler::ADDRESS nextPC;
+				int crFlags;
+
+				rc = nextAddr(pc, nextPC, crFlags);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: processTraceMessage(): Could not compute next address for PROFILER_CTF conversion\n");
+					return TraceDqrProfiler::DQERR_ERR;
+				}
+
+				// we will store the target address back in ckdata[1] in case it is needed later
+
+				nm.ict.ckdata[1] = nextPC;
+
+				if (ctf != nullptr) {
+					//ctf->addCall(nm.coreId, pc, nextPC, ts);
+				}
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitCallRet(nm.coreId, ts, nm.ictWS.ckdf, pc, faddr, TraceDqrProfiler::isCall);
+				}
+			}
+			else if (nm.ictWS.ckdf == 1) {
+				pc = nm.ictWS.ckdata[0] << 1;
+				faddr = pc ^ (nm.ictWS.ckdata[1] << 1);
+
+				if ((ctf != nullptr) || (eventConverter != nullptr)) {
+					TraceDqrProfiler::DQErr rc;
+					TraceDqrProfiler::ADDRESS nextPC;
+					int crFlags;
+
+					rc = nextAddr(pc, nextPC, crFlags);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: processTraceMessage(): Could not compute next address for PROFILER_CTF conversion\n");
+						return TraceDqrProfiler::DQERR_ERR;
+					}
+
+					if (ctf != nullptr) {
+						if (crFlags & TraceDqrProfiler::isCall) {
+							//ctf->addCall(nm.coreId, pc, faddr, ts);
+						}
+						else if ((crFlags & TraceDqrProfiler::isReturn) || (crFlags & TraceDqrProfiler::isExceptionReturn)) {
+							//ctf->addRet(nm.coreId, pc, faddr, ts);
+						}
+						else {
+							printf("Error: processTraceMEssage(): Unsupported crFlags in PROFILER_CTF conversion\n");
+							return TraceDqrProfiler::DQERR_ERR;
+						}
+					}
+
+					if (eventConverter != nullptr) {
+						//eventConverter->emitCallRet(nm.coreId, ts, nm.ictWS.ckdf, pc, faddr, crFlags);
+					}
+				}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		case TraceDqrProfiler::ICT_EXCEPTION:
+			if (nm.ictWS.ckdf == 1) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitException(nm.coreId, ts, nm.ictWS.ckdf, pc, nm.ictWS.ckdata[1]);
+			}
+			break;
+		case TraceDqrProfiler::ICT_INTERRUPT:
+			if (nm.ictWS.ckdf == 1) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitInterrupt(nm.coreId, ts, nm.ictWS.ckdf, pc, nm.ictWS.ckdata[1]);
+			}
+			break;
+		case TraceDqrProfiler::ICT_CONTEXT:
+			if (nm.ictWS.ckdf == 1) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitContext(nm.coreId, ts, nm.ictWS.ckdf, pc, nm.ictWS.ckdata[1]);
+			}
+			break;
+		case TraceDqrProfiler::ICT_PC_SAMPLE:
+			if (nm.ictWS.ckdf == 0) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				pc = faddr;
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+
+			if (eventConverter != nullptr) {
+				//eventConverter->emitPeriodic(nm.coreId, ts, nm.ictWS.ckdf, pc);
+			}
+			break;
+		case TraceDqrProfiler::ICT_CONTROL:
+			if (nm.ictWS.ckdf == 0) {
+				// nothing to do
+				// does not update faddr or pc!
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitControl(nm.coreId, ts, nm.ictWS.ckdf, nm.ictWS.ckdata[0], 0);
+				}
+			}
+			else if (nm.ictWS.ckdf == 1) {
+				faddr = nm.ictWS.ckdata[0] << 1;
+				pc = faddr;
+
+				if (eventConverter != nullptr) {
+					//eventConverter->emitControl(nm.coreId, ts, nm.ictWS.ckdf, nm.ictWS.ckdata[1], pc);
+				}
+			}
+			else {
+				printf("Error: processTraceMessage(): Invalid ckdf field: %d\n", nm.ictWS.ckdf);
+				return TraceDqrProfiler::DQERR_ERR;
+			}
+			break;
+		default:
+			printf("Error: processTraceMessage(): Invalid ICT Event: %d\n", nm.ictWS.cksrc);
+			return TraceDqrProfiler::DQERR_ERR;
+		}
+		break;
+	case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+	case TraceDqrProfiler::TCODE_DEVICE_ID:
+	case TraceDqrProfiler::TCODE_DATA_WRITE:
+	case TraceDqrProfiler::TCODE_DATA_READ:
+	case TraceDqrProfiler::TCODE_CORRECTION:
+	case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+	case TraceDqrProfiler::TCODE_DATA_READ_WS:
+	case TraceDqrProfiler::TCODE_WATCHPOINT:
+	case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+	case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+	case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+	case TraceDqrProfiler::TCODE_REPEATBRANCH:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+	case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+	case TraceDqrProfiler::TCODE_UNDEFINED:
+	default:
+		printf("Error: TraceProfiler::processTraceMessage(): Unsupported TCODE\n");
+
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::getInstructionByAddress(TraceDqrProfiler::ADDRESS addr, ProfilerInstruction* instInfo, ProfilerSource* srcInfo, int* flags)
+{
+	TraceDqrProfiler::DQErr rc;
+
+	rc = Disassemble(addr); // should error check disassembl() call!
+	if (rc != TraceDqrProfiler::DQERR_OK) {
+		return TraceDqrProfiler::DQERR_ERR;
+	}
+
+	*flags = 0;
+
+	if (instInfo != nullptr) {
+		instructionInfo.qDepth = 0;
+		instructionInfo.arithInProcess = 0;
+		instructionInfo.loadInProcess = 0;
+		instructionInfo.storeInProcess = 0;
+
+		instructionInfo.coreId = 0;
+		*instInfo = instructionInfo;
+		instInfo->CRFlag = TraceDqrProfiler::isNone;
+		instInfo->brFlags = TraceDqrProfiler::BRFLAG_none;
+
+		instInfo->timestamp = lastTime[currentCore];
+
+		*flags |= TraceDqrProfiler::TRACE_HAVE_INSTINFO;
+	}
+
+	if (srcInfo != nullptr) {
+		sourceInfo.coreId = 0;
+		*srcInfo = sourceInfo;
+		*flags |= TraceDqrProfiler::TRACE_HAVE_SRCINFO;
+	}
+
+	return TraceDqrProfiler::DQERR_OK;
+}
+
+TraceDqrProfiler::DQErr TraceProfiler::NextInstruction(ProfilerInstruction* instInfo, ProfilerNexusMessage* msgInfo, ProfilerSource* srcInfo, int* flags)
+{
+	TraceDqrProfiler::DQErr ec;
+
+	ProfilerInstruction* instInfop = nullptr;
+	ProfilerNexusMessage* msgInfop = nullptr;
+	ProfilerSource* srcInfop = nullptr;
+
+	ProfilerInstruction** instInfopp = nullptr;
+	ProfilerNexusMessage** msgInfopp = nullptr;
+	ProfilerSource** srcInfopp = nullptr;
+
+	if (instInfo != nullptr) {
+		instInfopp = &instInfop;
+	}
+
+	if (msgInfo != nullptr) {
+		msgInfopp = &msgInfop;
+	}
+
+	if (srcInfo != nullptr) {
+		srcInfopp = &srcInfop;
+	}
+
+	ec = NextInstruction(instInfopp, msgInfopp, srcInfopp);
+
+	*flags = 0;
+
+	if (ec == TraceDqrProfiler::DQERR_OK) {
+		if (instInfo != nullptr) {
+			if (instInfop != nullptr) {
+				*instInfo = *instInfop;
+				*flags |= TraceDqrProfiler::TRACE_HAVE_INSTINFO;
+			}
+		}
+
+		if (msgInfo != nullptr) {
+			if (msgInfop != nullptr) {
+				*msgInfo = *msgInfop;
+				*flags |= TraceDqrProfiler::TRACE_HAVE_MSGINFO;
+			}
+		}
+
+		if (srcInfo != nullptr) {
+			if (srcInfop != nullptr) {
+				*srcInfo = *srcInfop;
+				*flags |= TraceDqrProfiler::TRACE_HAVE_SRCINFO;
+			}
+		}
+
+		if (itcPrint != nullptr) {
+			if (itcPrint->haveITCPrintMsgs() != false) {
+				*flags |= TraceDqrProfiler::TRACE_HAVE_ITCPRINTINFO;
+			}
+		}
+	}
+
+	return ec;
+}
+TraceDqrProfiler::DQErr TraceProfiler::NextInstruction(ProfilerInstruction** instInfo, uint64_t& address_out)
+{
+	if (status != TraceDqrProfiler::DQERR_OK) 
+	{
+		return status;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+	TraceDqrProfiler::ADDRESS addr;
+	int crFlag;
+	TraceDqrProfiler::BranchFlags brFlags;
+	uint32_t caFlags = 0;
+	uint32_t pipeCycles = 0;
+	uint32_t viStartCycles = 0;
+	uint32_t viFinishCycles = 0;
+
+	uint8_t qDepth = 0;
+	uint8_t arithInProcess = 0;
+	uint8_t loadInProcess = 0;
+	uint8_t storeInProcess = 0;
+
+	bool consumed = false;
+
+	ProfilerInstruction** savedInstPtr = nullptr;
+	ProfilerNexusMessage** savedMsgPtr = nullptr;
+	ProfilerSource** savedSrcPtr = nullptr;
+
+	//if (instInfo != nullptr) 
+	//{
+	//	*instInfo = nullptr;
+	//}
+
+	for (;;) {
+		//		need to set readNewTraceMessage where it is needed! That includes
+		//		staying in the same state that expects to get another message!!
+
+		bool haveMsg;
+
+		if (savedInstPtr != nullptr) {
+			instInfo = savedInstPtr;
+			savedInstPtr = nullptr;
+		}
+
+		if (readNewTraceMessage != false) 
+		{
+			do 
+			{
+				rc = sfp->readNextTraceMsg(nm, analytics, haveMsg);
+
+				if (rc != TraceDqrProfiler::DQERR_OK) 
+				{
+					// have an error. either EOF, or error
+
+					status = rc;
+
+					if (status == TraceDqrProfiler::DQERR_EOF) {
+						state[currentCore] = TRACE_STATE_DONE;
+					}
+					else {
+						printf("Error: TraceProfiler file does not contain any trace messages, or is unreadable\n");
+
+						state[currentCore] = TRACE_STATE_ERROR;
+					}
+
+					return status;
+				}
+
+				if (haveMsg == false) 
+				{
+					lastTime[currentCore] = 0;
+					currentAddress[currentCore] = 0;
+					lastFaddr[currentCore] = 0;
+
+					state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+				}
+			} while (haveMsg == false);
+
+			readNewTraceMessage = false;
+			currentCore = nm.coreId;
+
+			// if set see if HTM trace message, switch to HTM mode
+
+			if (traceType != TraceDqrProfiler::TRACETYPE_HTM) {
+				switch (nm.tcode) {
+				case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+				case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				case TraceDqrProfiler::TCODE_ERROR:
+				case TraceDqrProfiler::TCODE_SYNC:
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+				case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+					break;
+				case TraceDqrProfiler::TCODE_CORRELATION:
+					if (nm.correlation.cdf == 1) {
+						traceType = TraceDqrProfiler::TRACETYPE_HTM;
+						if (profiler_globalDebugFlag) printf("TCODE_CORRELATION, cdf == 1: switching to HTM mode\n");
+					}
+					break;
+				case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+					traceType = TraceDqrProfiler::TRACETYPE_HTM;
+					if (profiler_globalDebugFlag) printf("History/taken/not taken count TCODE: switching to HTM mode\n");
+					break;
+				case TraceDqrProfiler::TCODE_REPEATBRANCH:
+				case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+				case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+				case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+				case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+				case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+				case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+				case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+				case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+				case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+				case TraceDqrProfiler::TCODE_DATA_READ_WS:
+				case TraceDqrProfiler::TCODE_WATCHPOINT:
+				case TraceDqrProfiler::TCODE_CORRECTION:
+				case TraceDqrProfiler::TCODE_DATA_WRITE:
+				case TraceDqrProfiler::TCODE_DATA_READ:
+				case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+				case TraceDqrProfiler::TCODE_DEVICE_ID:
+					printf("Error: NextInstruction(): Unsupported tcode type (%d)\n", nm.tcode);
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				case TraceDqrProfiler::TCODE_UNDEFINED:
+					printf("Error: NextInstruction(): Undefined tcode type (%d)\n", nm.tcode);
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+			}
+
+			// Check if this is a ICT Control message and if we are filtering them out
+#if 0
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				if ((nm.getCKSRC() == TraceDqrProfiler::ICT_CONTROL) && (eventFilterMask & (1 << PROFILER_CTF::et_controlIndex))) {
+					savedInstPtr = instInfo;
+					instInfo = nullptr;
+				}
+				break;
+			default:
+				break;
+			}
+#endif
+		}
+
+		switch (state[currentCore]) 
+		{
+		case TRACE_STATE_SYNCCATE:	// Looking for a CA trace sync
+			// printf("TRACE_STATE_SYNCCATE\n");
+
+			if (caTrace == nullptr) {
+				// have an error! Should never have TRACE_STATE_SYNC without a caTrace ptr
+				printf("Error: caTrace is null\n");
+				status = TraceDqrProfiler::DQERR_ERR;
+				state[currentCore] = TRACE_STATE_ERROR;
+				return status;
+			}
+
+			// loop through trace messages until we find a sync of some kind. First sync should do it
+			// sync reason must be correct (exit debug or start tracing) or we stay in this state
+
+			TraceDqrProfiler::ADDRESS teAddr;
+
+			switch (nm.tcode) 
+			{
+			case TraceDqrProfiler::TCODE_ERROR:
+				// reset time. Messages have been missed. Address may not still be 0 if we have seen a sync
+				// message without an exit debug or start trace sync reason, so reset address
+
+				lastTime[currentCore] = 0;
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+
+
+				readNewTraceMessage = true;
+
+				status = TraceDqrProfiler::DQERR_OK;
+
+				return status;
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_REPEATBRANCH:
+			case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+			case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+			case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+			case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+			case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+			case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+			case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+				// here we return the trace messages before we have actually started tracing
+				// this could be at the start of a trace, or after leaving a trace because of
+				// a correlation message
+
+						// we may have a valid address and time already if we saw a sync without an exit debug				        // or start trace sync reason. So call processTraceMessage()
+
+				if (lastFaddr[currentCore] != 0) {
+					rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+						status = TraceDqrProfiler::DQERR_ERR;
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						return status;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				status = TraceDqrProfiler::DQERR_OK;
+
+				return status;
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+				// sync reason should be either EXIT_DEBUG or TRACE_ENABLE. Otherwise, keep looking
+
+				TraceDqrProfiler::SyncReason sr;
+
+				sr = nm.getSyncReason();
+				switch (sr) {
+				case TraceDqrProfiler::SYNC_EXIT_DEBUG:
+				case TraceDqrProfiler::SYNC_TRACE_ENABLE:
+					// only exit debug or trace enable allow proceeding. All others stay in this state and return
+
+					teAddr = nm.getF_Addr() << 1;
+					break;
+				case TraceDqrProfiler::SYNC_EVTI:
+				case TraceDqrProfiler::SYNC_EXIT_RESET:
+				case TraceDqrProfiler::SYNC_T_CNT:
+				case TraceDqrProfiler::SYNC_I_CNT_OVERFLOW:
+				case TraceDqrProfiler::SYNC_WATCHPINT:
+				case TraceDqrProfiler::SYNC_FIFO_OVERRUN:
+				case TraceDqrProfiler::SYNC_EXIT_POWERDOWN:
+				case TraceDqrProfiler::SYNC_MESSAGE_CONTENTION:
+				case TraceDqrProfiler::SYNC_PC_SAMPLE:
+					// here we return the trace messages before we have actually started tracing
+					// this could be at the start of a trace, or after leaving a trace because of
+					// a correlation message
+					// probably should never get here when doing a CA trace.
+
+					rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+						status = TraceDqrProfiler::DQERR_ERR;
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						return status;
+					}
+
+
+
+					readNewTraceMessage = true;
+
+					status = TraceDqrProfiler::DQERR_OK;
+
+					return status;
+				case TraceDqrProfiler::SYNC_NONE:
+				default:
+					printf("Error: invalid sync reason\n");
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+				break;
+#if 0
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// INCIRCUTTRACE_WS messages do not have a sync reason, but control(0,1) has
+				// the same info!
+
+				TraceDqrProfiler::ICTReason itcr;
+
+				itcr = nm.getCKSRC();
+
+				switch (itcr) {
+				case TraceDqrProfiler::ICT_INFERABLECALL:
+				case TraceDqrProfiler::ICT_EXT_TRIG:
+				case TraceDqrProfiler::ICT_EXCEPTION:
+				case TraceDqrProfiler::ICT_INTERRUPT:
+				case TraceDqrProfiler::ICT_CONTEXT:
+				case TraceDqrProfiler::ICT_WATCHPOINT:
+				case TraceDqrProfiler::ICT_PC_SAMPLE:
+					rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+						status = TraceDqrProfiler::DQERR_ERR;
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						return status;
+					}
+
+
+					readNewTraceMessage = true;
+
+					status = TraceDqrProfiler::DQERR_OK;
+
+					return status;
+				case TraceDqrProfiler::ICT_CONTROL:
+					bool returnFlag;
+					returnFlag = true;
+
+					if (nm.ictWS.ckdf == 1) {
+						switch (nm.ictWS.ckdata[1]) {
+						case TraceDqrProfiler::ICT_CONTROL_TRACE_ON:
+						case TraceDqrProfiler::ICT_CONTROL_EXIT_DEBUG:
+							// only exit debug or trace enable allow proceeding. All others stay in this state and return
+
+							teAddr = nm.getF_Addr() << 1;
+							returnFlag = false;
+							break;
+						default:
+							break;
+						}
+					}
+
+					if (returnFlag) {
+						rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+						if (rc != TraceDqrProfiler::DQERR_OK) {
+							printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+							status = TraceDqrProfiler::DQERR_ERR;
+							state[currentCore] = TRACE_STATE_ERROR;
+
+							return status;
+						}
+
+	
+
+						readNewTraceMessage = true;
+
+						status = TraceDqrProfiler::DQERR_OK;
+
+						return status;
+					}
+					break;
+				case TraceDqrProfiler::ICT_NONE:
+				default:
+					printf("Error: invalid ICT reason\n");
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+				break;
+#endif
+			case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+			case TraceDqrProfiler::TCODE_DEVICE_ID:
+			case TraceDqrProfiler::TCODE_DATA_WRITE:
+			case TraceDqrProfiler::TCODE_DATA_READ:
+			case TraceDqrProfiler::TCODE_CORRECTION:
+			case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+			case TraceDqrProfiler::TCODE_DATA_READ_WS:
+			case TraceDqrProfiler::TCODE_WATCHPOINT:
+			case TraceDqrProfiler::TCODE_UNDEFINED:
+			default:
+				printf("Error: nextInstruction(): state TRACE_STATE_SYNCCATE: unsupported or invalid TCODE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+
+			// run ca code until we get to the te trace address. only do 6 instructions a the most
+#if 0
+			caSyncAddr = caTrace->getCATraceStartAddr();
+
+			//			printf("caSyncAddr: %08x, teAddr: %08x\n",caSyncAddr,teAddr);
+
+			//			caTrace->dumpCurrentCARecord(1);
+
+			TraceDqrProfiler::ADDRESS savedAddr;
+			savedAddr = -1;
+
+			bool fail;
+			fail = false;
+
+			for (int i = 0; (fail == false) && (teAddr != caSyncAddr) && (i < 30); i++) {
+				rc = nextCAAddr(caSyncAddr, savedAddr);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					fail = true;
+				}
+				else {
+					//					printf("caSyncAddr: %08x, teAddr: %08x\n",caSyncAddr,teAddr);
+
+					rc = caTrace->consume(caFlags, TraceDqrProfiler::INST_SCALER, pipeCycles, viStartCycles, viFinishCycles, qDepth, arithInProcess, loadInProcess, storeInProcess);
+					if (rc == TraceDqrProfiler::DQERR_EOF) {
+						state[currentCore] = TRACE_STATE_DONE;
+
+						status = rc;
+						return rc;
+					}
+
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						status = rc;
+						return status;
+					}
+				}
+			}
+
+			//			if (teAddr == caSyncAddr) {
+			//				printf("ca sync found at address %08x, cycles: %d\n",caSyncAddr,cycles);
+			//			}
+
+			if (teAddr != caSyncAddr) {
+				// unable to sync by fast-forwarding the CA trace to match the instruction trace
+				// so we will try to run the normal trace for a few instructions with the hope it
+				// will sync up with the ca trace! We set the max number of instructions to run
+				// the normal trace below, and turn tracing loose!
+
+				syncCount = 16;
+				caTrace->rewind();
+				caSyncAddr = caTrace->getCATraceStartAddr();
+
+				//				printf("starting normal trace to sync up; caSyncAddr: %08x\n",caSyncAddr);
+			}
+
+			// readnextmessage should be false. So, we want to process the message like a normal message here
+			// if the addresses of the trace and the start of the ca trace sync later, it is handled in
+			// the other states
+#endif
+			state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+			break;
+		case TRACE_STATE_GETFIRSTSYNCMSG:
+			// start here for normal traces
+
+			// read trace messages until a sync is found. Should be the first message normally
+			// unless the wrapped buffer
+
+			// only exit this state when sync type message is found or EOF or error
+			// Event messages will cause state to change to TRACE_STATE_EVENT
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETFIRSTSYNCMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+
+				state[currentCore] = TRACE_STATE_GETMSGWITHCOUNT;
+				break;
+#if 0
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// this may set the timestamp, and and may set the address
+				// all set the address except control(0,0) which is used just to set the timestamp at most
+
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETFIRSTSYNCMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if (currentAddress[currentCore] == 0) {
+					// for the get first sync state, we want currentAddress to be set
+					// most incircuttrace_ws types will set it, but not 8,0; 14,0; 0,0
+
+					currentAddress[currentCore] = lastFaddr[currentCore];
+				}
+
+				if ((nm.ictWS.cksrc == TraceDqrProfiler::ICT_CONTROL) && (nm.ictWS.ckdf == 0)) {
+					// ICT_WS Control(0,0) only updates TS (if present). Does not change state or anything else
+					// because it is the only incircuittrace message type with no address
+				}
+				else {
+					if ((nm.getCKSRC() == TraceDqrProfiler::ICT_EXT_TRIG) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+					}
+					else if ((nm.getCKSRC() == TraceDqrProfiler::ICT_WATCHPOINT) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+					}
+					else if ((instInfo != nullptr)) {
+						Disassemble(currentAddress[currentCore]);
+
+						if (instInfo != nullptr) {
+							instructionInfo.qDepth = 0;
+							instructionInfo.arithInProcess = 0;
+							instructionInfo.loadInProcess = 0;
+							instructionInfo.storeInProcess = 0;
+
+							instructionInfo.coreId = currentCore;
+							*instInfo = &instructionInfo;
+							//							(*instInfo)->CRFlag = TraceDqrProfiler::isNone;
+							//							(*instInfo)->brFlags = TraceDqrProfiler::BRFLAG_none;
+							getCRBRFlags(nm.getCKSRC(), currentAddress[currentCore], (*instInfo)->CRFlag, (*instInfo)->brFlags);
+
+							(*instInfo)->timestamp = lastTime[currentCore];
+						}
+
+					}
+					state[currentCore] = TRACE_STATE_GETMSGWITHCOUNT;
+				}
+				break;
+#endif
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETFIRSTSYNCMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+				if (nm.timestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+				break;
+			case TraceDqrProfiler::TCODE_ERROR:
+				// reset time. Messages have been missed.
+				lastTime[currentCore] = 0;
+				break;
+			case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+			case TraceDqrProfiler::TCODE_DEVICE_ID:
+			case TraceDqrProfiler::TCODE_DATA_WRITE:
+			case TraceDqrProfiler::TCODE_DATA_READ:
+			case TraceDqrProfiler::TCODE_CORRECTION:
+			case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+			case TraceDqrProfiler::TCODE_DATA_READ_WS:
+			case TraceDqrProfiler::TCODE_WATCHPOINT:
+			default:
+				printf("Error: nextInstructin(): state TRACE_STATE_GETFIRSTSYNCMSG: unsupported or invalid TCODE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+
+			// INCIRCUITTRACE or INCIRCUITTRACE_WS will have set state to TRACE_STATE_EVENT
+
+			readNewTraceMessage = true;
+
+			// here we return the trace messages before we have actually started tracing
+			// this could be at the start of a trace, or after leaving a trace because of
+			// a correlation message
+
+			status = TraceDqrProfiler::DQERR_OK;
+			return status;
+		case TRACE_STATE_GETMSGWITHCOUNT:
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				// don't update timestamp until messages are retired!
+
+				// reset all counts before setting them. We have no valid counts before the second message.
+				// first message is a sync-type message. Counts are for up to that message, nothing after.
+
+				counts->resetCounts(currentCore);
+
+				rc = counts->setCounts(&nm);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					state[currentCore] = TRACE_STATE_ERROR;
+					status = rc;
+
+					return status;
+				}
+
+				// only these TCODEs have counts and release from this state
+
+				state[currentCore] = TRACE_STATE_GETNEXTINSTRUCTION;
+				break;
+#if 0
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// these message have no counts so they will be retired immediately
+
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETMSGWITHCOUNT: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if ((nm.getCKSRC() == TraceDqrProfiler::ICT_CONTROL) && (nm.getCKDF() == 0)) {
+					// ICT_WS Control(0,0) only updates TS (if present). Does not change state or anything else
+					addr = currentAddress[currentCore];
+				}
+				else {
+					if ((nm.getCKSRC() == TraceDqrProfiler::ICT_EXT_TRIG) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+						addr = lastFaddr[currentCore];
+					}
+					else if ((nm.getCKSRC() == TraceDqrProfiler::ICT_WATCHPOINT) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction tracaes
+						addr = lastFaddr[currentCore];
+					}
+					else if ((instInfo != nullptr)) {
+						addr = currentAddress[currentCore];
+
+						Disassemble(addr);
+
+						if (instInfo != nullptr) {
+							instructionInfo.qDepth = 0;
+							instructionInfo.arithInProcess = 0;
+							instructionInfo.loadInProcess = 0;
+							instructionInfo.storeInProcess = 0;
+
+							instructionInfo.coreId = currentCore;
+							*instInfo = &instructionInfo;
+							//							(*instInfo)->CRFlag = TraceDqrProfiler::isNone;
+							//							(*instInfo)->brFlags = TraceDqrProfiler::BRFLAG_none;
+							getCRBRFlags(nm.getCKSRC(), currentAddress[currentCore], (*instInfo)->CRFlag, (*instInfo)->brFlags);
+							(*instInfo)->timestamp = lastTime[currentCore];
+						}
+
+					}
+					state[currentCore] = TRACE_STATE_GETMSGWITHCOUNT;
+				}
+
+
+
+				readNewTraceMessage = true;
+
+				return status;
+#endif
+			case TraceDqrProfiler::TCODE_ERROR:
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+
+				nm.timestamp = 0;	// clear time because we have lost time
+				lastTime[currentCore] = 0;
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETMSGWITHCOUNT: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				// these message have no address or count info, so we still need to get
+				// another message.
+
+				// might want to keep track of process, but will add that later
+
+				// for now, return message;
+
+				if (nm.haveTimestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+
+
+				readNewTraceMessage = true;
+
+				return status;
+			default:
+				printf("Error: bad tcode type in state TRACE_STATE_GETMSGWITHCOUNT. TCODE (%d)\n", nm.tcode);
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+			break;
+		case TRACE_STATE_RETIREMESSAGE:
+			switch (nm.tcode) {
+				// sync type messages say where to set pc to
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_RETIREMESSAGE: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				// I don't think the b_type code below actaully does anything??? Remove??
+
+				TraceDqrProfiler::BType b_type;
+				b_type = TraceDqrProfiler::BTYPE_UNDEFINED;
+
+				switch (nm.tcode) {
+				case TraceDqrProfiler::TCODE_SYNC:
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+					break;
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+					if ((nm.ictWS.cksrc == TraceDqrProfiler::ICT_EXCEPTION) || (nm.ictWS.cksrc == TraceDqrProfiler::ICT_INTERRUPT)) {
+						b_type = TraceDqrProfiler::BTYPE_EXCEPTION;
+					}
+					break;
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+					if ((nm.ict.cksrc == TraceDqrProfiler::ICT_EXCEPTION) || (nm.ict.cksrc == TraceDqrProfiler::ICT_INTERRUPT)) {
+						b_type = TraceDqrProfiler::BTYPE_EXCEPTION;
+					}
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+					b_type = nm.indirectBranchWS.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+					b_type = nm.indirectBranch.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+					b_type = nm.indirectHistory.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+					b_type = nm.indirectHistoryWS.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+				case TraceDqrProfiler::TCODE_RESOURCEFULL:
+					// fall through
+				default:
+					break;
+				}
+
+				if (b_type == TraceDqrProfiler::BTYPE_EXCEPTION) {
+					enterISR[currentCore] = TraceDqrProfiler::isInterrupt;
+				}
+
+				readNewTraceMessage = true;
+				state[currentCore] = TRACE_STATE_GETNEXTMSG;
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// these messages should have been retired immediately
+
+				printf("Error: unexpected tcode of INCIRCUTTRACE or INCIRCUTTRACE_WS in state TRACE_STATE_RETIREMESSAGE\n");
+				state[currentCore] = TRACE_STATE_ERROR;
+
+				status = TraceDqrProfiler::DQERR_ERR;
+				return status;
+			case TraceDqrProfiler::TCODE_CORRELATION:
+				// correlation has i_cnt, but no address info
+
+				if (nm.haveTimestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+
+
+
+				readNewTraceMessage = true;
+
+				// leaving trace mode - need to get next sync
+
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+				break;
+			case TraceDqrProfiler::TCODE_ERROR:
+				printf("Error: Unexpected tcode TCODE_ERROR in state TRACE_STATE_RETIREMESSAGE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				// these messages have no address or i-cnt info and should have been
+				// instantly retired when they were read.
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			default:
+				printf("Error: bad tcode type in state TRACE_STATE_RETIREMESSAGE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+
+			status = TraceDqrProfiler::DQERR_OK;
+			return status;
+		case TRACE_STATE_GETNEXTMSG:
+			//			printf("TRACE_STATE_GETNEXTMSG\n");
+
+						// exit this state when message with i-cnt, history, taken, or not-taken is read
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				rc = counts->setCounts(&nm);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: nextInstruction: state TRACE_STATE_GETNEXTMESSAGE Count::seteCounts()\n");
+
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					status = rc;
+
+					return status;
+				}
+
+				state[currentCore] = TRACE_STATE_GETNEXTINSTRUCTION;
+				break;
+#if 0
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// these message have no counts so they will be retired immeadiately
+
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETMSGWITHCOUNT: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if ((nm.getCKSRC() == TraceDqrProfiler::ICT_CONTROL) && (nm.getCKDF() == 0)) {
+					// ICT_WS Control(0,0) only updates TS (if present). Does not change state or anything else
+					addr = currentAddress[currentCore];
+				}
+				else {
+					if ((nm.getCKSRC() == TraceDqrProfiler::ICT_EXT_TRIG) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+						addr = lastFaddr[currentCore];
+					}
+					else if ((nm.getCKSRC() == TraceDqrProfiler::ICT_WATCHPOINT) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction tracaes
+						addr = lastFaddr[currentCore];
+					}
+					else if ((instInfo != nullptr)) {
+						addr = currentAddress[currentCore];
+
+						Disassemble(addr);
+
+						if (instInfo != nullptr) {
+							instructionInfo.qDepth = 0;
+							instructionInfo.arithInProcess = 0;
+							instructionInfo.loadInProcess = 0;
+							instructionInfo.storeInProcess = 0;
+
+							instructionInfo.coreId = currentCore;
+							*instInfo = &instructionInfo;
+							//							(*instInfo)->CRFlag = TraceDqrProfiler::isNone;
+							//							(*instInfo)->brFlags = TraceDqrProfiler::BRFLAG_none;
+							getCRBRFlags(nm.getCKSRC(), currentAddress[currentCore], (*instInfo)->CRFlag, (*instInfo)->brFlags);
+
+							(*instInfo)->timestamp = lastTime[currentCore];
+						}
+
+
+					}
+				}
+
+
+				readNewTraceMessage = true;
+
+				return status;
+#endif
+			case TraceDqrProfiler::TCODE_ERROR:
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+
+				nm.timestamp = 0;	// clear time because we have lost time
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+				lastTime[currentCore] = 0;
+
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETNXTMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				// retire these instantly by returning them through msgInfo
+
+				if (nm.haveTimestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+
+
+				// leave state along. Need to get another message with an i-cnt!
+
+				readNewTraceMessage = true;
+
+				return status;
+			default:
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+			break;
+		case TRACE_STATE_GETNEXTINSTRUCTION:
+			if (counts->getCurrentCountType(currentCore) == TraceDqrProfiler::COUNTTYPE_none) {
+				if (profiler_globalDebugFlag) {
+					printf("NextInstruction(): counts are exhausted\n");
+				}
+
+				state[currentCore] = TRACE_STATE_RETIREMESSAGE;
+				break;
+			}
+
+			addr = currentAddress[currentCore];
+			address_out = addr;
+			uint32_t inst;
+			int inst_size;
+			TraceDqrProfiler::InstType inst_type;
+			int32_t immediate;
+			bool isBranch;
+			int rc;
+			TraceDqrProfiler::Reg rs1;
+			TraceDqrProfiler::Reg rd;
+
+			// getInstrucitonByAddress() should cache last instrucioton/address because I thjink
+			// it gets called a couple times for each address/insruction in a row
+#if 0
+			status = elfReader->getInstructionByAddress(addr, inst);
+			if (status != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: getInstructionByAddress failed - looking for next sync message\n");
+
+				lastTime[currentCore] = 0;
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+
+				// the evil break below exits the switch statement - not the if statement!
+
+				break;
+
+				//				state[currentCore] = TRACE_STATE_ERROR;
+				//
+				//				return status;
+			}
+
+			// figure out how big the instruction is
+
+//			decode instruction/decode instruction size should cache their results (at least last one)
+//			because it gets called a few times here!
+
+			rc = decodeInstruction(inst, inst_size, inst_type, rs1, rd, immediate, isBranch);
+			if (rc != 0) {
+				printf("Error: Cann't decode size of instruction %04x\n", inst);
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+#endif
+#if 0
+			Disassemble(addr);
+#endif
+			// compute next address (retire this instruction)
+
+			// nextAddr() will also update counts
+			//
+			// nextAddr() computes next address if possible, consumes counts
+
+			// nextAddr can usually compute the next address, but not always. If it can't, it returns
+			// -1 as the next address.  This should never happen for conditional branches because we
+			// should always have enough informatioon. But it can happen for indirect branches. For indirect
+			// branches, retiring the current trace message (should be an indirect branch or indirect
+			// brnach with sync) will set the next address correclty.
+
+			status = nextAddr(currentCore, currentAddress[currentCore], addr, nm.tcode, crFlag, brFlags);
+			if (status != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: nextAddr() failed\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+
+				return status;
+			}
+
+			// if addr == -1 and brFlags == BRFLAG_unknown, we need to read another trace message
+			// which hopefully with have history bits. Do not return the instruciton yet - we will
+			// retry it after getting another trace message
+
+			// if addr == -1 and brflags != BRFLAG_unknown, and current counts type != none, we have an
+			// error.
+
+			// if addr == -1 and brflags != BRFLAG_unkonw and current count type == none, all should
+			// be good. We will return the instruction and read another message
+
+			if (addr == (TraceDqrProfiler::ADDRESS)-1) {
+				if (brFlags == TraceDqrProfiler::BRFLAG_unknown) {
+					// read another trace message and retry
+
+					state[currentCore] = TRACE_STATE_RETIREMESSAGE;
+					break; // this break exits trace_state_getnextinstruction!
+				}
+				else if (counts->getCurrentCountType(currentCore) != TraceDqrProfiler::COUNTTYPE_none) {
+					// error
+					// must have a JR/JALR or exception/exception return to get here, and the CR stack is empty
+
+					printf("Error: getCurrentCountType(core:%d) still has counts; have countType: %d\n", currentCore, counts->getCurrentCountType(currentCore));
+					char d[64];
+
+					instructionInfo.instructionToText(d, sizeof d, 2);
+					printf("%08llx:    %s\n", currentAddress[currentCore], d);
+
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					return status;
+				}
+			}
+
+			currentAddress[currentCore] = addr;
+
+			uint32_t prevCycle;
+			prevCycle = 0;
+#if 0
+			if (caTrace != nullptr) {
+				if (syncCount > 0) {
+					if (caSyncAddr == instructionInfo.address) {
+						//						printf("ca sync successful at addr %08x\n",caSyncAddr);
+
+						syncCount = 0;
+					}
+					else {
+						syncCount -= 1;
+						if (syncCount == 0) {
+							printf("Error: unable to sync CA trace and instruction trace\n");
+							state[currentCore] = TRACE_STATE_ERROR;
+							status = TraceDqrProfiler::DQERR_ERR;
+							return status;
+						}
+					}
+				}
+
+				if (syncCount == 0) {
+					status = caTrace->consume(caFlags, inst_type, pipeCycles, viStartCycles, viFinishCycles, qDepth, arithInProcess, loadInProcess, storeInProcess);
+					if (status == TraceDqrProfiler::DQERR_EOF) {
+						state[currentCore] = TRACE_STATE_DONE;
+						return status;
+					}
+
+					if (status != TraceDqrProfiler::DQERR_OK) {
+						state[currentCore] = TRACE_STATE_ERROR;
+						return status;
+					}
+
+					prevCycle = lastCycle[currentCore];
+
+					eCycleCount[currentCore] = pipeCycles - prevCycle;
+
+					lastCycle[currentCore] = pipeCycles;
+				}
+			}
+#endif
+
+			if (instInfo != nullptr) 
+			{
+				instructionInfo.qDepth = qDepth;
+				instructionInfo.arithInProcess = arithInProcess;
+				instructionInfo.loadInProcess = loadInProcess;
+				instructionInfo.storeInProcess = storeInProcess;
+
+				qDepth = 0;
+				arithInProcess = 0;
+				loadInProcess = 0;
+				storeInProcess = 0;
+
+				instructionInfo.coreId = currentCore;
+				*instInfo = &instructionInfo;
+				(*instInfo)->CRFlag = (crFlag | enterISR[currentCore]);
+				enterISR[currentCore] = TraceDqrProfiler::isNone;
+				(*instInfo)->brFlags = brFlags;
+
+				if ((caTrace != nullptr) && (syncCount == 0)) {
+					// note: start signal is one cycle after execution begins. End signal is two cycles after end
+
+					(*instInfo)->timestamp = pipeCycles;
+					(*instInfo)->pipeCycles = eCycleCount[currentCore];
+
+					(*instInfo)->VIStartCycles = viStartCycles - prevCycle;
+					(*instInfo)->VIFinishCycles = viFinishCycles - prevCycle - 1;
+
+					(*instInfo)->caFlags = caFlags;
+				}
+				else {
+					(*instInfo)->timestamp = lastTime[currentCore];
+				}
+			}
+
+			//			lastCycle[currentCore] = cycles;
+
+#if 0
+			status = analytics.updateInstructionInfo(currentCore, inst, inst_size, crFlag, brFlags);
+			if (status != TraceDqrProfiler::DQERR_OK) {
+				state[currentCore] = TRACE_STATE_ERROR;
+
+				printf("Error: updateInstructionInfo() failed\n");
+				return status;
+			}
+#endif
+
+			if (counts->getCurrentCountType(currentCore) != TraceDqrProfiler::COUNTTYPE_none) {
+				// still have valid counts. Keep running nextInstruction!
+
+				return status;
+			}
+
+			// counts have expired. Retire this message and read next trace message and update. This should cause the
+			// current process instruction (above) to be returned along with the retired trace message
+
+			// if the instruction processed above in an indirect branch, counts should be zero and
+			// retiring this trace message should set the next address (message should be an indirect
+			// brnach type message)
+
+			state[currentCore] = TRACE_STATE_RETIREMESSAGE;
+			break;
+		case TRACE_STATE_DONE:
+			status = TraceDqrProfiler::DQERR_DONE;
+			return status;
+		case TRACE_STATE_ERROR:
+			status = TraceDqrProfiler::DQERR_ERR;
+			return status;
+		default:
+			printf("Error: TraceProfiler::NextInstruction():unknown\n");
+
+			state[currentCore] = TRACE_STATE_ERROR;
+			status = TraceDqrProfiler::DQERR_ERR;
+			return status;
+		}
+	}
+
+	status = TraceDqrProfiler::DQERR_OK;
+	return TraceDqrProfiler::DQERR_OK;
+}
+//NextInstruction() want to return address, instruction, trace message if any, label+offset for instruction, target of instruciton
+//		source code for instruction (file, function, line)
+//
+//		return instruction object (include label informatioon)
+//		return message object
+//		return source code object//
+//
+//				if instruction object ptr is null, don't return any instruction info
+//				if message object ptr is null, don't return any message info
+//				if source code object is null, don't return source code info
+
+TraceDqrProfiler::DQErr TraceProfiler::NextInstruction(ProfilerInstruction** instInfo, ProfilerNexusMessage** msgInfo, ProfilerSource** srcInfo)
+{
+	if (sfp == nullptr) {
+		printf("Error: TraceProfiler::NextInstructin(): Null sfp object\n");
+
+		status = TraceDqrProfiler::DQERR_ERR;
+		return status;
+	}
+
+	if (status != TraceDqrProfiler::DQERR_OK) {
+		return status;
+	}
+
+	TraceDqrProfiler::DQErr rc;
+	TraceDqrProfiler::ADDRESS addr;
+	int crFlag;
+	TraceDqrProfiler::BranchFlags brFlags;
+	uint32_t caFlags = 0;
+	uint32_t pipeCycles = 0;
+	uint32_t viStartCycles = 0;
+	uint32_t viFinishCycles = 0;
+
+	uint8_t qDepth = 0;
+	uint8_t arithInProcess = 0;
+	uint8_t loadInProcess = 0;
+	uint8_t storeInProcess = 0;
+
+	bool consumed = false;
+
+	ProfilerInstruction** savedInstPtr = nullptr;
+	ProfilerNexusMessage** savedMsgPtr = nullptr;
+	ProfilerSource** savedSrcPtr = nullptr;
+
+	if (instInfo != nullptr) {
+		*instInfo = nullptr;
+	}
+
+	if (msgInfo != nullptr) {
+		*msgInfo = nullptr;
+	}
+
+	if (srcInfo != nullptr) {
+		*srcInfo = nullptr;
+	}
+
+	for (;;) {
+		//		need to set readNewTraceMessage where it is needed! That includes
+		//		staying in the same state that expects to get another message!!
+
+		bool haveMsg;
+
+		if (savedInstPtr != nullptr) {
+			instInfo = savedInstPtr;
+			savedInstPtr = nullptr;
+		}
+
+		if (savedMsgPtr != nullptr) {
+			msgInfo = savedMsgPtr;
+			savedMsgPtr = nullptr;
+		}
+
+		if (savedSrcPtr != nullptr) {
+			srcInfo = savedSrcPtr;
+			savedSrcPtr = nullptr;
+		}
+
+		if (readNewTraceMessage != false) {
+			do {
+				rc = sfp->readNextTraceMsg(nm, analytics, haveMsg);
+
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					// have an error. either EOF, or error
+
+					status = rc;
+
+					if (status == TraceDqrProfiler::DQERR_EOF) {
+						state[currentCore] = TRACE_STATE_DONE;
+					}
+					else {
+						printf("Error: TraceProfiler file does not contain any trace messages, or is unreadable\n");
+
+						state[currentCore] = TRACE_STATE_ERROR;
+					}
+
+					return status;
+				}
+
+				if (haveMsg == false) {
+					lastTime[currentCore] = 0;
+					currentAddress[currentCore] = 0;
+					lastFaddr[currentCore] = 0;
+
+					state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+				}
+			} while (haveMsg == false);
+
+			readNewTraceMessage = false;
+			currentCore = nm.coreId;
+
+			// if set see if HTM trace message, switch to HTM mode
+
+			if (traceType != TraceDqrProfiler::TRACETYPE_HTM) {
+				switch (nm.tcode) {
+				case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+				case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				case TraceDqrProfiler::TCODE_ERROR:
+				case TraceDqrProfiler::TCODE_SYNC:
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+				case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+					break;
+				case TraceDqrProfiler::TCODE_CORRELATION:
+					if (nm.correlation.cdf == 1) {
+						traceType = TraceDqrProfiler::TRACETYPE_HTM;
+						if (profiler_globalDebugFlag) printf("TCODE_CORRELATION, cdf == 1: switching to HTM mode\n");
+					}
+					break;
+				case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+					traceType = TraceDqrProfiler::TRACETYPE_HTM;
+					if (profiler_globalDebugFlag) printf("History/taken/not taken count TCODE: switching to HTM mode\n");
+					break;
+				case TraceDqrProfiler::TCODE_REPEATBRANCH:
+				case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+				case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+				case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+				case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+				case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+				case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+				case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+				case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+				case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+				case TraceDqrProfiler::TCODE_DATA_READ_WS:
+				case TraceDqrProfiler::TCODE_WATCHPOINT:
+				case TraceDqrProfiler::TCODE_CORRECTION:
+				case TraceDqrProfiler::TCODE_DATA_WRITE:
+				case TraceDqrProfiler::TCODE_DATA_READ:
+				case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+				case TraceDqrProfiler::TCODE_DEVICE_ID:
+					printf("Error: NextInstruction(): Unsupported tcode type (%d)\n", nm.tcode);
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				case TraceDqrProfiler::TCODE_UNDEFINED:
+					printf("Error: NextInstruction(): Undefined tcode type (%d)\n", nm.tcode);
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+			}
+
+			// Check if this is a ICT Control message and if we are filtering them out
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				if ((nm.getCKSRC() == TraceDqrProfiler::ICT_CONTROL) && (eventFilterMask & (1 << PROFILER_CTF::et_controlIndex))) {
+					savedInstPtr = instInfo;
+					instInfo = nullptr;
+					savedMsgPtr = msgInfo;
+					msgInfo = nullptr;
+					savedSrcPtr = srcInfo;
+					srcInfo = nullptr;
+				}
+				break;
+			default:
+				break;
+			}
+		}
+
+		switch (state[currentCore]) {
+		case TRACE_STATE_SYNCCATE:	// Looking for a CA trace sync
+			// printf("TRACE_STATE_SYNCCATE\n");
+
+			if (caTrace == nullptr) {
+				// have an error! Should never have TRACE_STATE_SYNC without a caTrace ptr
+				printf("Error: caTrace is null\n");
+				status = TraceDqrProfiler::DQERR_ERR;
+				state[currentCore] = TRACE_STATE_ERROR;
+				return status;
+			}
+
+			// loop through trace messages until we find a sync of some kind. First sync should do it
+			// sync reason must be correct (exit debug or start tracing) or we stay in this state
+
+			TraceDqrProfiler::ADDRESS teAddr;
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_ERROR:
+				// reset time. Messages have been missed. Address may not still be 0 if we have seen a sync
+				// message without an exit debug or start trace sync reason, so reset address
+
+				lastTime[currentCore] = 0;
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+
+					// currentAddresss should be 0 until we get a sync message. TS has been set to 0
+
+					messageInfo.currentAddress = currentAddress[currentCore];
+					messageInfo.time = lastTime[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				status = TraceDqrProfiler::DQERR_OK;
+
+				return status;
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_REPEATBRANCH:
+			case TraceDqrProfiler::TCODE_REPEATINSTRUCTION:
+			case TraceDqrProfiler::TCODE_REPEATINSTRUCTION_WS:
+			case TraceDqrProfiler::TCODE_AUXACCESS_READNEXT:
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITENEXT:
+			case TraceDqrProfiler::TCODE_AUXACCESS_RESPONSE:
+			case TraceDqrProfiler::TCODE_OUTPUT_PORTREPLACEMENT:
+			case TraceDqrProfiler::TCODE_INPUT_PORTREPLACEMENT:
+			case TraceDqrProfiler::TCODE_AUXACCESS_READ:
+				// here we return the trace messages before we have actually started tracing
+				// this could be at the start of a trace, or after leaving a trace because of
+				// a correlation message
+
+						// we may have a valid address and time already if we saw a sync without an exit debug				        // or start trace sync reason. So call processTraceMessage()
+
+				if (lastFaddr[currentCore] != 0) {
+					rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+						status = TraceDqrProfiler::DQERR_ERR;
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						return status;
+					}
+				}
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+
+					// currentAddresss should be 0 until we get a sync message. TS may
+					// have been set by a ICT control WS message
+
+					messageInfo.currentAddress = currentAddress[currentCore];
+					messageInfo.time = lastTime[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				status = TraceDqrProfiler::DQERR_OK;
+
+				return status;
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+				// sync reason should be either EXIT_DEBUG or TRACE_ENABLE. Otherwise, keep looking
+
+				TraceDqrProfiler::SyncReason sr;
+
+				sr = nm.getSyncReason();
+				switch (sr) {
+				case TraceDqrProfiler::SYNC_EXIT_DEBUG:
+				case TraceDqrProfiler::SYNC_TRACE_ENABLE:
+					// only exit debug or trace enable allow proceeding. All others stay in this state and return
+
+					teAddr = nm.getF_Addr() << 1;
+					break;
+				case TraceDqrProfiler::SYNC_EVTI:
+				case TraceDqrProfiler::SYNC_EXIT_RESET:
+				case TraceDqrProfiler::SYNC_T_CNT:
+				case TraceDqrProfiler::SYNC_I_CNT_OVERFLOW:
+				case TraceDqrProfiler::SYNC_WATCHPINT:
+				case TraceDqrProfiler::SYNC_FIFO_OVERRUN:
+				case TraceDqrProfiler::SYNC_EXIT_POWERDOWN:
+				case TraceDqrProfiler::SYNC_MESSAGE_CONTENTION:
+				case TraceDqrProfiler::SYNC_PC_SAMPLE:
+					// here we return the trace messages before we have actually started tracing
+					// this could be at the start of a trace, or after leaving a trace because of
+					// a correlation message
+					// probably should never get here when doing a CA trace.
+
+					rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+						status = TraceDqrProfiler::DQERR_ERR;
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						return status;
+					}
+
+					if (msgInfo != nullptr) {
+						messageInfo = nm;
+
+						// if doing pc-sampling and msg type is INCIRCUITTRACE_WS, we want to use faddr
+						// and not currentAddress
+
+						messageInfo.currentAddress = nm.getF_Addr() << 1;
+
+						if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+							*msgInfo = &messageInfo;
+						}
+					}
+
+					readNewTraceMessage = true;
+
+					status = TraceDqrProfiler::DQERR_OK;
+
+					return status;
+				case TraceDqrProfiler::SYNC_NONE:
+				default:
+					printf("Error: invalid sync reason\n");
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// INCIRCUTTRACE_WS messages do not have a sync reason, but control(0,1) has
+				// the same info!
+
+				TraceDqrProfiler::ICTReason itcr;
+
+				itcr = nm.getCKSRC();
+
+				switch (itcr) {
+				case TraceDqrProfiler::ICT_INFERABLECALL:
+				case TraceDqrProfiler::ICT_EXT_TRIG:
+				case TraceDqrProfiler::ICT_EXCEPTION:
+				case TraceDqrProfiler::ICT_INTERRUPT:
+				case TraceDqrProfiler::ICT_CONTEXT:
+				case TraceDqrProfiler::ICT_WATCHPOINT:
+				case TraceDqrProfiler::ICT_PC_SAMPLE:
+					rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+						status = TraceDqrProfiler::DQERR_ERR;
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						return status;
+					}
+
+					if (msgInfo != nullptr) {
+						messageInfo = nm;
+
+						// if doing pc-sampling and msg type is INCIRCUITTRACE_WS, we want to use faddr
+						// and not currentAddress
+
+						messageInfo.currentAddress = nm.getF_Addr() << 1;
+
+						if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+							*msgInfo = &messageInfo;
+						}
+					}
+
+					readNewTraceMessage = true;
+
+					status = TraceDqrProfiler::DQERR_OK;
+
+					return status;
+				case TraceDqrProfiler::ICT_CONTROL:
+					bool returnFlag;
+					returnFlag = true;
+
+					if (nm.ictWS.ckdf == 1) {
+						switch (nm.ictWS.ckdata[1]) {
+						case TraceDqrProfiler::ICT_CONTROL_TRACE_ON:
+						case TraceDqrProfiler::ICT_CONTROL_EXIT_DEBUG:
+							// only exit debug or trace enable allow proceeding. All others stay in this state and return
+
+							teAddr = nm.getF_Addr() << 1;
+							returnFlag = false;
+							break;
+						default:
+							break;
+						}
+					}
+
+					if (returnFlag) {
+						rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+						if (rc != TraceDqrProfiler::DQERR_OK) {
+							printf("Error: NextInstruction(): state TRACE_STATE_SYNCCATE: processTraceMessage()\n");
+
+							status = TraceDqrProfiler::DQERR_ERR;
+							state[currentCore] = TRACE_STATE_ERROR;
+
+							return status;
+						}
+
+						if (msgInfo != nullptr) {
+							messageInfo = nm;
+
+							// if doing pc-sampling and msg type is INCIRCUITTRACE_WS, we want to use faddr
+							// and not currentAddress
+
+							messageInfo.currentAddress = nm.getF_Addr() << 1;
+
+							if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+								*msgInfo = &messageInfo;
+							}
+						}
+
+						readNewTraceMessage = true;
+
+						status = TraceDqrProfiler::DQERR_OK;
+
+						return status;
+					}
+					break;
+				case TraceDqrProfiler::ICT_NONE:
+				default:
+					printf("Error: invalid ICT reason\n");
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+				break;
+			case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+			case TraceDqrProfiler::TCODE_DEVICE_ID:
+			case TraceDqrProfiler::TCODE_DATA_WRITE:
+			case TraceDqrProfiler::TCODE_DATA_READ:
+			case TraceDqrProfiler::TCODE_CORRECTION:
+			case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+			case TraceDqrProfiler::TCODE_DATA_READ_WS:
+			case TraceDqrProfiler::TCODE_WATCHPOINT:
+			case TraceDqrProfiler::TCODE_UNDEFINED:
+			default:
+				printf("Error: nextInstruction(): state TRACE_STATE_SYNCCATE: unsupported or invalid TCODE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+
+			// run ca code until we get to the te trace address. only do 6 instructions a the most
+
+			caSyncAddr = caTrace->getCATraceStartAddr();
+
+			//			printf("caSyncAddr: %08x, teAddr: %08x\n",caSyncAddr,teAddr);
+
+			//			caTrace->dumpCurrentCARecord(1);
+
+			TraceDqrProfiler::ADDRESS savedAddr;
+			savedAddr = -1;
+
+			bool fail;
+			fail = false;
+
+			for (int i = 0; (fail == false) && (teAddr != caSyncAddr) && (i < 30); i++) {
+				rc = nextCAAddr(caSyncAddr, savedAddr);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					fail = true;
+				}
+				else {
+					//					printf("caSyncAddr: %08x, teAddr: %08x\n",caSyncAddr,teAddr);
+
+					rc = caTrace->consume(caFlags, TraceDqrProfiler::INST_SCALER, pipeCycles, viStartCycles, viFinishCycles, qDepth, arithInProcess, loadInProcess, storeInProcess);
+					if (rc == TraceDqrProfiler::DQERR_EOF) {
+						state[currentCore] = TRACE_STATE_DONE;
+
+						status = rc;
+						return rc;
+					}
+
+					if (rc != TraceDqrProfiler::DQERR_OK) {
+						state[currentCore] = TRACE_STATE_ERROR;
+
+						status = rc;
+						return status;
+					}
+				}
+			}
+
+			//			if (teAddr == caSyncAddr) {
+			//				printf("ca sync found at address %08x, cycles: %d\n",caSyncAddr,cycles);
+			//			}
+
+			if (teAddr != caSyncAddr) {
+				// unable to sync by fast-forwarding the CA trace to match the instruction trace
+				// so we will try to run the normal trace for a few instructions with the hope it
+				// will sync up with the ca trace! We set the max number of instructions to run
+				// the normal trace below, and turn tracing loose!
+
+				syncCount = 16;
+				caTrace->rewind();
+				caSyncAddr = caTrace->getCATraceStartAddr();
+
+				//				printf("starting normal trace to sync up; caSyncAddr: %08x\n",caSyncAddr);
+			}
+
+			// readnextmessage should be false. So, we want to process the message like a normal message here
+			// if the addresses of the trace and the start of the ca trace sync later, it is handled in
+			// the other states
+
+			state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+			break;
+		case TRACE_STATE_GETFIRSTSYNCMSG:
+			// start here for normal traces
+
+			// read trace messages until a sync is found. Should be the first message normally
+			// unless the wrapped buffer
+
+			// only exit this state when sync type message is found or EOF or error
+			// Event messages will cause state to change to TRACE_STATE_EVENT
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETFIRSTSYNCMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if (srcInfo != nullptr) {
+					Disassemble(currentAddress[currentCore]);
+
+					sourceInfo.coreId = currentCore;
+					*srcInfo = &sourceInfo;
+				}
+
+				state[currentCore] = TRACE_STATE_GETMSGWITHCOUNT;
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// this may set the timestamp, and and may set the address
+				// all set the address except control(0,0) which is used just to set the timestamp at most
+
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETFIRSTSYNCMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if (currentAddress[currentCore] == 0) {
+					// for the get first sync state, we want currentAddress to be set
+					// most incircuttrace_ws types will set it, but not 8,0; 14,0; 0,0
+
+					currentAddress[currentCore] = lastFaddr[currentCore];
+				}
+
+				if ((nm.ictWS.cksrc == TraceDqrProfiler::ICT_CONTROL) && (nm.ictWS.ckdf == 0)) {
+					// ICT_WS Control(0,0) only updates TS (if present). Does not change state or anything else
+					// because it is the only incircuittrace message type with no address
+				}
+				else {
+					if ((nm.getCKSRC() == TraceDqrProfiler::ICT_EXT_TRIG) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+					}
+					else if ((nm.getCKSRC() == TraceDqrProfiler::ICT_WATCHPOINT) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+					}
+					else if ((instInfo != nullptr) || (srcInfo != nullptr)) {
+						Disassemble(currentAddress[currentCore]);
+
+						if (instInfo != nullptr) {
+							instructionInfo.qDepth = 0;
+							instructionInfo.arithInProcess = 0;
+							instructionInfo.loadInProcess = 0;
+							instructionInfo.storeInProcess = 0;
+
+							instructionInfo.coreId = currentCore;
+							*instInfo = &instructionInfo;
+							//							(*instInfo)->CRFlag = TraceDqrProfiler::isNone;
+							//							(*instInfo)->brFlags = TraceDqrProfiler::BRFLAG_none;
+							getCRBRFlags(nm.getCKSRC(), currentAddress[currentCore], (*instInfo)->CRFlag, (*instInfo)->brFlags);
+
+							(*instInfo)->timestamp = lastTime[currentCore];
+						}
+
+						if (srcInfo != nullptr) {
+							sourceInfo.coreId = currentCore;
+							*srcInfo = &sourceInfo;
+						}
+					}
+					state[currentCore] = TRACE_STATE_GETMSGWITHCOUNT;
+				}
+				break;
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETFIRSTSYNCMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+				if (nm.timestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+				break;
+			case TraceDqrProfiler::TCODE_ERROR:
+				// reset time. Messages have been missed.
+				lastTime[currentCore] = 0;
+				break;
+			case TraceDqrProfiler::TCODE_DEBUG_STATUS:
+			case TraceDqrProfiler::TCODE_DEVICE_ID:
+			case TraceDqrProfiler::TCODE_DATA_WRITE:
+			case TraceDqrProfiler::TCODE_DATA_READ:
+			case TraceDqrProfiler::TCODE_CORRECTION:
+			case TraceDqrProfiler::TCODE_DATA_WRITE_WS:
+			case TraceDqrProfiler::TCODE_DATA_READ_WS:
+			case TraceDqrProfiler::TCODE_WATCHPOINT:
+			default:
+				printf("Error: nextInstructin(): state TRACE_STATE_GETFIRSTSYNCMSG: unsupported or invalid TCODE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+
+			// INCIRCUITTRACE or INCIRCUITTRACE_WS will have set state to TRACE_STATE_EVENT
+
+			readNewTraceMessage = true;
+
+			// here we return the trace messages before we have actually started tracing
+			// this could be at the start of a trace, or after leaving a trace because of
+			// a correlation message
+
+			if (msgInfo != nullptr) {
+				messageInfo = nm;
+
+				messageInfo.currentAddress = currentAddress[currentCore];
+
+				messageInfo.time = lastTime[currentCore];
+
+				if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+					*msgInfo = &messageInfo;
+				}
+			}
+
+			status = TraceDqrProfiler::DQERR_OK;
+			return status;
+		case TRACE_STATE_GETMSGWITHCOUNT:
+
+			// think GETMSGWITHCOUNT and GETNEXTMSG state are the same!! If so, combine them!
+
+//			printf("TRACE_STATE_GETMSGWITHCOUNT %08x\n",lastFaddr[currentCore]);
+			// only message with i-cnt/hist/taken/notTaken will release from this state
+
+			// return any message without a count (i-cnt or hist, taken/not taken)
+
+			// do not return message with i-cnt/hist/taken/not taken; process them when counts expires
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				// don't update timestamp until messages are retired!
+
+				// reset all counts before setting them. We have no valid counts before the second message.
+				// first message is a sync-type message. Counts are for up to that message, nothing after.
+
+				counts->resetCounts(currentCore);
+
+				rc = counts->setCounts(&nm);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					state[currentCore] = TRACE_STATE_ERROR;
+					status = rc;
+
+					return status;
+				}
+
+				// only these TCODEs have counts and release from this state
+
+				state[currentCore] = TRACE_STATE_GETNEXTINSTRUCTION;
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// these message have no counts so they will be retired immediately
+
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETMSGWITHCOUNT: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if ((nm.getCKSRC() == TraceDqrProfiler::ICT_CONTROL) && (nm.getCKDF() == 0)) {
+					// ICT_WS Control(0,0) only updates TS (if present). Does not change state or anything else
+					addr = currentAddress[currentCore];
+				}
+				else {
+					if ((nm.getCKSRC() == TraceDqrProfiler::ICT_EXT_TRIG) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+						addr = lastFaddr[currentCore];
+					}
+					else if ((nm.getCKSRC() == TraceDqrProfiler::ICT_WATCHPOINT) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction tracaes
+						addr = lastFaddr[currentCore];
+					}
+					else if ((instInfo != nullptr) || (srcInfo != nullptr)) {
+						addr = currentAddress[currentCore];
+
+						Disassemble(addr);
+
+						if (instInfo != nullptr) {
+							instructionInfo.qDepth = 0;
+							instructionInfo.arithInProcess = 0;
+							instructionInfo.loadInProcess = 0;
+							instructionInfo.storeInProcess = 0;
+
+							instructionInfo.coreId = currentCore;
+							*instInfo = &instructionInfo;
+							//							(*instInfo)->CRFlag = TraceDqrProfiler::isNone;
+							//							(*instInfo)->brFlags = TraceDqrProfiler::BRFLAG_none;
+							getCRBRFlags(nm.getCKSRC(), currentAddress[currentCore], (*instInfo)->CRFlag, (*instInfo)->brFlags);
+							(*instInfo)->timestamp = lastTime[currentCore];
+						}
+
+						if (srcInfo != nullptr) {
+							sourceInfo.coreId = currentCore;
+							*srcInfo = &sourceInfo;
+						}
+					}
+					state[currentCore] = TRACE_STATE_GETMSGWITHCOUNT;
+				}
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = addr;
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_ERROR:
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+
+				// don't update timestamp because we have missed some
+				//
+				// if (nm.haveTimestamp) {
+				//	lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel,lastTime[currentCore],nm.timestamp);
+				// }
+
+				nm.timestamp = 0;	// clear time because we have lost time
+				lastTime[currentCore] = 0;
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = currentAddress[currentCore];
+
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETMSGWITHCOUNT: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				// for now, return message;
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = currentAddress[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				// these message have no address or count info, so we still need to get
+				// another message.
+
+				// might want to keep track of process, but will add that later
+
+				// for now, return message;
+
+				if (nm.haveTimestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = currentAddress[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				return status;
+			default:
+				printf("Error: bad tcode type in state TRACE_STATE_GETMSGWITHCOUNT. TCODE (%d)\n", nm.tcode);
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+			break;
+		case TRACE_STATE_RETIREMESSAGE:
+			//			printf("TRACE_STATE_RETIREMESSAGE\n");
+
+						// Process message being retired (currently in nm) i_cnt/taken/not taken/history has gone to 0
+						// compute next address
+
+			//			set lastFaddr,currentAddress,lastTime.
+			//			readNewTraceMessage = true;
+			//			state = Trace_State_GetNextMsg;
+			//			return messageInfo.
+
+						// retire message should be run anytime any count expires - i-cnt, history, taken, not taken
+
+			switch (nm.tcode) {
+				// sync type messages say where to set pc to
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_RETIREMESSAGE: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+
+					messageInfo.currentAddress = currentAddress[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				if ((srcInfo != nullptr) && (*srcInfo == nullptr)) {
+					Disassemble(currentAddress[currentCore]);
+
+					sourceInfo.coreId = currentCore;
+					*srcInfo = &sourceInfo;
+				}
+
+				// I don't think the b_type code below actaully does anything??? Remove??
+
+				TraceDqrProfiler::BType b_type;
+				b_type = TraceDqrProfiler::BTYPE_UNDEFINED;
+
+				switch (nm.tcode) {
+				case TraceDqrProfiler::TCODE_SYNC:
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+					break;
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+					if ((nm.ictWS.cksrc == TraceDqrProfiler::ICT_EXCEPTION) || (nm.ictWS.cksrc == TraceDqrProfiler::ICT_INTERRUPT)) {
+						b_type = TraceDqrProfiler::BTYPE_EXCEPTION;
+					}
+					break;
+				case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+					if ((nm.ict.cksrc == TraceDqrProfiler::ICT_EXCEPTION) || (nm.ict.cksrc == TraceDqrProfiler::ICT_INTERRUPT)) {
+						b_type = TraceDqrProfiler::BTYPE_EXCEPTION;
+					}
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+					b_type = nm.indirectBranchWS.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+					b_type = nm.indirectBranch.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+					b_type = nm.indirectHistory.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+					b_type = nm.indirectHistoryWS.b_type;
+					break;
+				case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+				case TraceDqrProfiler::TCODE_RESOURCEFULL:
+					// fall through
+				default:
+					break;
+				}
+
+				if (b_type == TraceDqrProfiler::BTYPE_EXCEPTION) {
+					enterISR[currentCore] = TraceDqrProfiler::isInterrupt;
+				}
+
+				readNewTraceMessage = true;
+				state[currentCore] = TRACE_STATE_GETNEXTMSG;
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// these messages should have been retired immediately
+
+				printf("Error: unexpected tcode of INCIRCUTTRACE or INCIRCUTTRACE_WS in state TRACE_STATE_RETIREMESSAGE\n");
+				state[currentCore] = TRACE_STATE_ERROR;
+
+				status = TraceDqrProfiler::DQERR_ERR;
+				return status;
+			case TraceDqrProfiler::TCODE_CORRELATION:
+				// correlation has i_cnt, but no address info
+
+				if (nm.haveTimestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+
+					// leaving trace mode - currentAddress should be last faddr + i_cnt *2
+
+					messageInfo.currentAddress = lastFaddr[currentCore] + nm.correlation.i_cnt * 2;
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				// leaving trace mode - need to get next sync
+
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+				break;
+			case TraceDqrProfiler::TCODE_ERROR:
+				printf("Error: Unexpected tcode TCODE_ERROR in state TRACE_STATE_RETIREMESSAGE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				// these messages have no address or i-cnt info and should have been
+				// instantly retired when they were read.
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			default:
+				printf("Error: bad tcode type in state TRACE_STATE_RETIREMESSAGE\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+
+			status = TraceDqrProfiler::DQERR_OK;
+			return status;
+		case TRACE_STATE_GETNEXTMSG:
+			//			printf("TRACE_STATE_GETNEXTMSG\n");
+
+						// exit this state when message with i-cnt, history, taken, or not-taken is read
+
+			switch (nm.tcode) {
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH:
+			case TraceDqrProfiler::TCODE_SYNC:
+			case TraceDqrProfiler::TCODE_DIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_INDIRECT_BRANCH_WS:
+			case TraceDqrProfiler::TCODE_CORRELATION:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY:
+			case TraceDqrProfiler::TCODE_INDIRECTBRANCHHISTORY_WS:
+			case TraceDqrProfiler::TCODE_RESOURCEFULL:
+				rc = counts->setCounts(&nm);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: nextInstruction: state TRACE_STATE_GETNEXTMESSAGE Count::seteCounts()\n");
+
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					status = rc;
+
+					return status;
+				}
+
+				state[currentCore] = TRACE_STATE_GETNEXTINSTRUCTION;
+				break;
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE:
+			case TraceDqrProfiler::TCODE_INCIRCUITTRACE_WS:
+				// these message have no counts so they will be retired immeadiately
+
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETMSGWITHCOUNT: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				if ((nm.getCKSRC() == TraceDqrProfiler::ICT_CONTROL) && (nm.getCKDF() == 0)) {
+					// ICT_WS Control(0,0) only updates TS (if present). Does not change state or anything else
+					addr = currentAddress[currentCore];
+				}
+				else {
+					if ((nm.getCKSRC() == TraceDqrProfiler::ICT_EXT_TRIG) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction traces
+						addr = lastFaddr[currentCore];
+					}
+					else if ((nm.getCKSRC() == TraceDqrProfiler::ICT_WATCHPOINT) && (nm.getCKDF() == 0)) {
+						// no dasm or src for ext trigger in HTM instruction tracaes
+						addr = lastFaddr[currentCore];
+					}
+					else if ((instInfo != nullptr) || (srcInfo != nullptr)) {
+						addr = currentAddress[currentCore];
+
+						Disassemble(addr);
+
+						if (instInfo != nullptr) {
+							instructionInfo.qDepth = 0;
+							instructionInfo.arithInProcess = 0;
+							instructionInfo.loadInProcess = 0;
+							instructionInfo.storeInProcess = 0;
+
+							instructionInfo.coreId = currentCore;
+							*instInfo = &instructionInfo;
+							//							(*instInfo)->CRFlag = TraceDqrProfiler::isNone;
+							//							(*instInfo)->brFlags = TraceDqrProfiler::BRFLAG_none;
+							getCRBRFlags(nm.getCKSRC(), currentAddress[currentCore], (*instInfo)->CRFlag, (*instInfo)->brFlags);
+
+							(*instInfo)->timestamp = lastTime[currentCore];
+						}
+
+						if (srcInfo != nullptr) {
+							sourceInfo.coreId = currentCore;
+							*srcInfo = &sourceInfo;
+						}
+					}
+				}
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = addr;
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_ERROR:
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+
+				nm.timestamp = 0;	// clear time because we have lost time
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+				lastTime[currentCore] = 0;
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = currentAddress[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_AUXACCESS_WRITE:
+			case TraceDqrProfiler::TCODE_DATA_ACQUISITION:
+				rc = processTraceMessage(nm, currentAddress[currentCore], lastFaddr[currentCore], lastTime[currentCore], consumed);
+				if (rc != TraceDqrProfiler::DQERR_OK) {
+					printf("Error: NextInstruction(): state TRACE_STATE_GETNXTMSG: processTraceMessage()\n");
+
+					status = TraceDqrProfiler::DQERR_ERR;
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					return status;
+				}
+
+				// for now, return message;
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = currentAddress[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				readNewTraceMessage = true;
+
+				return status;
+			case TraceDqrProfiler::TCODE_OWNERSHIP_TRACE:
+				// retire these instantly by returning them through msgInfo
+
+				if (nm.haveTimestamp) {
+					lastTime[currentCore] = processTS(TraceDqrProfiler::TS_rel, lastTime[currentCore], nm.timestamp);
+				}
+
+				if (msgInfo != nullptr) {
+					messageInfo = nm;
+					messageInfo.time = lastTime[currentCore];
+					messageInfo.currentAddress = currentAddress[currentCore];
+
+					if ((consumed == false) && (messageInfo.processITCPrintData(itcPrint) == false)) {
+						*msgInfo = &messageInfo;
+					}
+				}
+
+				// leave state along. Need to get another message with an i-cnt!
+
+				readNewTraceMessage = true;
+
+				return status;
+			default:
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+			break;
+		case TRACE_STATE_GETNEXTINSTRUCTION:
+			if (counts->getCurrentCountType(currentCore) == TraceDqrProfiler::COUNTTYPE_none) {
+				if (profiler_globalDebugFlag) {
+					printf("NextInstruction(): counts are exhausted\n");
+				}
+
+				state[currentCore] = TRACE_STATE_RETIREMESSAGE;
+				break;
+			}
+
+			//			printf("state TRACE_STATE_GETNEXTINSTRUCTION\n");
+
+						// Should first process addr, and then compute next addr!!! If can't compute next addr, it is an error.
+						// Should always be able to process instruction at addr and compute next addr when we get here.
+						// After processing next addr, if there are no more counts, retire trace message and get another
+
+			addr = currentAddress[currentCore];
+
+			uint32_t inst;
+			int inst_size;
+			TraceDqrProfiler::InstType inst_type;
+			int32_t immediate;
+			bool isBranch;
+			int rc;
+			TraceDqrProfiler::Reg rs1;
+			TraceDqrProfiler::Reg rd;
+
+			// getInstrucitonByAddress() should cache last instrucioton/address because I thjink
+			// it gets called a couple times for each address/insruction in a row
+
+			status = elfReader->getInstructionByAddress(addr, inst);
+			if (status != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: getInstructionByAddress failed - looking for next sync message\n");
+
+				lastTime[currentCore] = 0;
+				currentAddress[currentCore] = 0;
+				lastFaddr[currentCore] = 0;
+
+				state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+
+				// the evil break below exits the switch statement - not the if statement!
+
+				break;
+
+				//				state[currentCore] = TRACE_STATE_ERROR;
+				//
+				//				return status;
+			}
+
+			// figure out how big the instruction is
+
+//			decode instruction/decode instruction size should cache their results (at least last one)
+//			because it gets called a few times here!
+
+			rc = decodeInstruction(inst, inst_size, inst_type, rs1, rd, immediate, isBranch);
+			if (rc != 0) {
+				printf("Error: Cann't decode size of instruction %04x\n", inst);
+
+				state[currentCore] = TRACE_STATE_ERROR;
+				status = TraceDqrProfiler::DQERR_ERR;
+
+				return status;
+			}
+
+			Disassemble(addr);
+
+			// compute next address (retire this instruction)
+
+			// nextAddr() will also update counts
+			//
+			// nextAddr() computes next address if possible, consumes counts
+
+			// nextAddr can usually compute the next address, but not always. If it can't, it returns
+			// -1 as the next address.  This should never happen for conditional branches because we
+			// should always have enough informatioon. But it can happen for indirect branches. For indirect
+			// branches, retiring the current trace message (should be an indirect branch or indirect
+			// brnach with sync) will set the next address correclty.
+
+			status = nextAddr(currentCore, currentAddress[currentCore], addr, nm.tcode, crFlag, brFlags);
+			if (status != TraceDqrProfiler::DQERR_OK) {
+				printf("Error: nextAddr() failed\n");
+
+				state[currentCore] = TRACE_STATE_ERROR;
+
+				return status;
+			}
+
+			// if addr == -1 and brFlags == BRFLAG_unknown, we need to read another trace message
+			// which hopefully with have history bits. Do not return the instruciton yet - we will
+			// retry it after getting another trace message
+
+			// if addr == -1 and brflags != BRFLAG_unknown, and current counts type != none, we have an
+			// error.
+
+			// if addr == -1 and brflags != BRFLAG_unkonw and current count type == none, all should
+			// be good. We will return the instruction and read another message
+
+			if (addr == (TraceDqrProfiler::ADDRESS)-1) {
+				if (brFlags == TraceDqrProfiler::BRFLAG_unknown) {
+					// read another trace message and retry
+
+					state[currentCore] = TRACE_STATE_RETIREMESSAGE;
+					break; // this break exits trace_state_getnextinstruction!
+				}
+				else if (counts->getCurrentCountType(currentCore) != TraceDqrProfiler::COUNTTYPE_none) {
+					// error
+					// must have a JR/JALR or exception/exception return to get here, and the CR stack is empty
+
+					printf("Error: getCurrentCountType(core:%d) still has counts; have countType: %d\n", currentCore, counts->getCurrentCountType(currentCore));
+					char d[64];
+
+					instructionInfo.instructionToText(d, sizeof d, 2);
+					printf("%08llx:    %s\n", currentAddress[currentCore], d);
+
+					state[currentCore] = TRACE_STATE_ERROR;
+
+					status = TraceDqrProfiler::DQERR_ERR;
+
+					//					nm.dumpRawMessage();
+					//					nm.dump();
+					//
+					//					rc = sfp->readNextTraceMsg(nm,analytics,haveMsg);
+					//
+					//					if (rc != TraceDqrProfiler::DQERR_OK) {
+					//						printf("Error: TraceProfiler file does not contain any trace messages, or is unreadable\n");
+					//					} else if (haveMsg != false) {
+					//						nm.dumpRawMessage();
+					//						nm.dump();
+					//					}
+
+					return status;
+				}
+			}
+
+			currentAddress[currentCore] = addr;
+
+			uint32_t prevCycle;
+			prevCycle = 0;
+
+			if (caTrace != nullptr) {
+				if (syncCount > 0) {
+					if (caSyncAddr == instructionInfo.address) {
+						//						printf("ca sync successful at addr %08x\n",caSyncAddr);
+
+						syncCount = 0;
+					}
+					else {
+						syncCount -= 1;
+						if (syncCount == 0) {
+							printf("Error: unable to sync CA trace and instruction trace\n");
+							state[currentCore] = TRACE_STATE_ERROR;
+							status = TraceDqrProfiler::DQERR_ERR;
+							return status;
+						}
+					}
+				}
+
+				if (syncCount == 0) {
+					status = caTrace->consume(caFlags, inst_type, pipeCycles, viStartCycles, viFinishCycles, qDepth, arithInProcess, loadInProcess, storeInProcess);
+					if (status == TraceDqrProfiler::DQERR_EOF) {
+						state[currentCore] = TRACE_STATE_DONE;
+						return status;
+					}
+
+					if (status != TraceDqrProfiler::DQERR_OK) {
+						state[currentCore] = TRACE_STATE_ERROR;
+						return status;
+					}
+
+					prevCycle = lastCycle[currentCore];
+
+					eCycleCount[currentCore] = pipeCycles - prevCycle;
+
+					lastCycle[currentCore] = pipeCycles;
+				}
+			}
+
+			if (instInfo != nullptr) {
+				instructionInfo.qDepth = qDepth;
+				instructionInfo.arithInProcess = arithInProcess;
+				instructionInfo.loadInProcess = loadInProcess;
+				instructionInfo.storeInProcess = storeInProcess;
+
+				qDepth = 0;
+				arithInProcess = 0;
+				loadInProcess = 0;
+				storeInProcess = 0;
+
+				instructionInfo.coreId = currentCore;
+				*instInfo = &instructionInfo;
+				(*instInfo)->CRFlag = (crFlag | enterISR[currentCore]);
+				enterISR[currentCore] = TraceDqrProfiler::isNone;
+				(*instInfo)->brFlags = brFlags;
+
+				if ((caTrace != nullptr) && (syncCount == 0)) {
+					// note: start signal is one cycle after execution begins. End signal is two cycles after end
+
+					(*instInfo)->timestamp = pipeCycles;
+					(*instInfo)->pipeCycles = eCycleCount[currentCore];
+
+					(*instInfo)->VIStartCycles = viStartCycles - prevCycle;
+					(*instInfo)->VIFinishCycles = viFinishCycles - prevCycle - 1;
+
+					(*instInfo)->caFlags = caFlags;
+				}
+				else {
+					(*instInfo)->timestamp = lastTime[currentCore];
+				}
+			}
+
+			//			lastCycle[currentCore] = cycles;
+
+			if (srcInfo != nullptr) {
+				sourceInfo.coreId = currentCore;
+				*srcInfo = &sourceInfo;
+			}
+
+			status = analytics.updateInstructionInfo(currentCore, inst, inst_size, crFlag, brFlags);
+			if (status != TraceDqrProfiler::DQERR_OK) {
+				state[currentCore] = TRACE_STATE_ERROR;
+
+				printf("Error: updateInstructionInfo() failed\n");
+				return status;
+			}
+
+
+			if (counts->getCurrentCountType(currentCore) != TraceDqrProfiler::COUNTTYPE_none) {
+				// still have valid counts. Keep running nextInstruction!
+
+				return status;
+			}
+
+			// counts have expired. Retire this message and read next trace message and update. This should cause the
+			// current process instruction (above) to be returned along with the retired trace message
+
+			// if the instruction processed above in an indirect branch, counts should be zero and
+			// retiring this trace message should set the next address (message should be an indirect
+			// brnach type message)
+
+			state[currentCore] = TRACE_STATE_RETIREMESSAGE;
+			break;
+		case TRACE_STATE_DONE:
+			status = TraceDqrProfiler::DQERR_DONE;
+			return status;
+		case TRACE_STATE_ERROR:
+			status = TraceDqrProfiler::DQERR_ERR;
+			return status;
+		default:
+			printf("Error: TraceProfiler::NextInstruction():unknown\n");
+
+			state[currentCore] = TRACE_STATE_ERROR;
+			status = TraceDqrProfiler::DQERR_ERR;
+			return status;
+		}
+	}
+
+	status = TraceDqrProfiler::DQERR_OK;
+	return TraceDqrProfiler::DQERR_OK;
+}

--- a/src/linuxutils.cpp
+++ b/src/linuxutils.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+       Module: linuxutils.cpp
+     Engineer: Vimalraj Rajasekharan
+  Description: Linux dependent utility functions
+
+  Date           Initials    Description
+  30-Nov-2023    VR          Initial
+  ****************************************************************************/
+#include "linuxutils.h"
+
+/****************************************************************************
+     Function: linuxevent_init
+        Input: linuxevent *ev
+                  Pointer to the linuxevent structure
+       Output: N/A
+  Description: Initialises the linuxevent
+Date         Initials    Description
+26-Nov-2015  MOH         Initial
+****************************************************************************/
+void linuxevent_init(linuxevent *ev) 
+{
+   pthread_mutex_init(&ev->mutex, 0);
+   pthread_cond_init(&ev->cond, 0);
+   ev->triggered = false;
+}
+
+/****************************************************************************
+     Function: linuxevent_trigger
+        Input: linuxevent *ev
+                  Pointer to the linuxevent structure
+       Output: N/A
+  Description: Triggers the linuxevent
+Date         Initials    Description
+26-Nov-2015  MOH         Initial
+****************************************************************************/
+void linuxevent_trigger(linuxevent *ev)
+{
+   pthread_mutex_lock(&ev->mutex);
+   ev->triggered = true;
+   pthread_cond_signal(&ev->cond);
+   pthread_mutex_unlock(&ev->mutex);
+}
+
+/****************************************************************************
+     Function: linuxevent_wait
+        Input: linuxevent *ev
+                  Pointer to the linuxevent structure
+       Output: N/A
+  Description: Waits for the linuxevent
+Date         Initials    Description
+26-Nov-2015  MOH         Initial
+****************************************************************************/
+void linuxevent_wait(linuxevent *ev)
+{
+   pthread_mutex_lock(&ev->mutex);
+   while (!ev->triggered)
+      pthread_cond_wait(&ev->cond, &ev->mutex);
+   ev->triggered = false;
+   pthread_mutex_unlock(&ev->mutex);
+}
+
+/****************************************************************************
+     Function: linuxevent_destroy
+        Input: linuxevent *ev
+                  Pointer to the linuxevent structure
+       Output: N/A
+  Description: Destroys the linuxevent
+Date         Initials    Description
+26-Nov-2015  MOH         Initial
+****************************************************************************/
+void linuxevent_destroy(linuxevent *ev) 
+{
+   pthread_cond_destroy(&ev->cond);
+   pthread_mutex_destroy(&ev->mutex);
+}
+
+/****************************************************************************
+     Function: closesocket
+        Input: lSOCKET socketfd
+                  Socket descriptor
+       Output: Error value
+  Description: Closes an open socket
+Date         Initials    Description
+30-Nov-2023  VR          Initial
+****************************************************************************/
+int closesocket(SOCKET socketfd)
+{
+    return close(socketfd);
+}
+
+int CreateThread(void *(*routine)(void *), void *arg)
+{
+    pthread_t tyThread;
+    return pthread_create(&tyThread, NULL, routine, arg);
+}


### PR DESCRIPTION
The profiler will stop profiling and return error if it is unable to compute the next address. This change will attempt to restart trace profiling from next sync point in case of error.